### PR TITLE
[B2BORG-34] Initialize field resolvers for B2BUser queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Initialize `B2BUser` query field resolvers
+- Don't set `sessionToken` header in `GraphQLServer` client if token is null
+
 ## [0.3.0] - 2021-11-01
 
 ### Added

--- a/node/clients/graphqlServer.ts
+++ b/node/clients/graphqlServer.ts
@@ -18,7 +18,9 @@ export class GraphQLServer extends AppClient {
           locale: this.context.locale,
         },
         headers: {
-          sessionToken: this.context.sessionToken,
+          ...(this.context.sessionToken && {
+            sessionToken: this.context.sessionToken,
+          }),
         },
         url: `/graphql`,
       }
@@ -33,7 +35,9 @@ export class GraphQLServer extends AppClient {
           locale: this.context.locale,
         },
         headers: {
-          sessionToken: this.context.sessionToken,
+          ...(this.context.sessionToken && {
+            sessionToken: this.context.sessionToken,
+          }),
         },
         url: `/graphql`,
       }

--- a/node/index.ts
+++ b/node/index.ts
@@ -45,6 +45,7 @@ export default new Service<Clients, RecorderState, ParamsContext>({
     resolvers: {
       Query: resolvers.Query,
       Mutation: resolvers.Mutation,
+      B2BUser: resolvers.B2BUser,
     },
     schemaDirectives,
   },

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -17,7 +17,7 @@ import {
 } from '../mdSchema'
 import { toHash } from '../utils'
 import GraphQLError from '../utils/GraphQLError'
-import { organizationName, costCenterName } from './fieldResolvers'
+import { organizationName, costCenterName, role } from './fieldResolvers'
 
 const getAppId = (): string => {
   return process.env.VTEX_APP_ID ?? ''
@@ -1447,5 +1447,6 @@ export const resolvers = {
   B2BUser: {
     organizationName,
     costCenterName,
+    role,
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Previous PR neglected to initialize the field resolvers for the B2BUser GraphQL type. This PR enables the query to return the organization name, cost center name, and role details.

#### How to test it?

GraphiQL: https://quotes--sandboxusdev.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.2.3/graphiql/v1?query=query%20%7B%0A%20%20getUsers(organizationId%3A%20%223394da75-3694-11ec-82ac-0e63d6323601%22)%20%7B%0A%20%20%20%20email%0A%20%20%20%20orgId%0A%20%20%20%20organizationName%0A%20%20%20%20costCenterName%0A%20%20%20%20role%20%7B%0A%20%20%20%20%20%20slug%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D
