### PR TITLE
Create new storefront queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Create separate queries for storefront users that check user's permissions
+
 ## [0.3.1] - 2021-11-02
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -19,6 +19,8 @@ type Query {
     sortedBy: String = "name"
   ): OrganizationResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
   getOrganizationById(id: ID): Organization
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @withPermissions
     @cacheControl(scope: PRIVATE)
@@ -28,11 +30,16 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): CostCenterResult
-    @withSession
-    @withPermissions
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): CostCenterResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
   getCostCentersByOrganizationId(
+    id: ID
+    search: String
+    page: Int = 1
+    pageSize: Int = 25
+    sortOrder: String = "ASC"
+    sortedBy: String = "name"
+  ): CostCenterResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  getCostCentersByOrganizationIdStorefront(
     id: ID
     search: String
     page: Int = 1
@@ -44,6 +51,8 @@ type Query {
     @withPermissions
     @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  getCostCenterByIdStorefront(id: ID!): CostCenter
     @withSession
     @withPermissions
     @cacheControl(scope: PUBLIC, maxAge: SHORT)


### PR DESCRIPTION
#### What problem is this solving?

Removed permission checks from `getOrganizationById`, `getCostCentersByOrganizationId`, `getCostCenterById` queries and created new (additional) storefront queries that return the same data but only if the user has the correct permissions.

#### How to test it?

GraphiQL: https://quotes--sandboxusdev.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.3.1/graphiql/v1?query=query%20%7B%0A%20%20getOrganizationById(id%3A%20%223394da75-3694-11ec-82ac-0e63d6323601%22)%20%7B%0A%20%20%20%20name%0A%20%20%20%20costCenters%0A%20%20%20%20collections%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D
