### PR TITLE
[B2BORG=42] Enable MD immediate indexing and deprecate field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable immediate indexing for MD schemas
+
+### Deprecated
+
+- `costCenters` property in organization schema (expect this to be an empty array)
+
 ## [0.8.0] - 2021-12-10
 
 ### Added

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -8,7 +8,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'notes',
   'created',
 ]
-export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.0.3'
+export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.0.4'
 
 export const ORGANIZATION_DATA_ENTITY = 'organizations'
 export const ORGANIZATION_FIELDS = [
@@ -21,7 +21,7 @@ export const ORGANIZATION_FIELDS = [
   'status',
   'created',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.5'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.6'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -31,7 +31,7 @@ export const COST_CENTER_FIELDS = [
   'paymentTerms',
   'organization',
 ]
-export const COST_CENTER_SCHEMA_VERSION = 'v0.0.3'
+export const COST_CENTER_SCHEMA_VERSION = 'v0.0.4'
 
 export const schemas = [
   {
@@ -66,6 +66,7 @@ export const schemas = [
         },
       },
       'v-indexed': ['name', 'status', 'created'],
+      'v-immediate-indexing': true,
       'v-cache': false,
     },
   },
@@ -90,8 +91,8 @@ export const schemas = [
           type: 'array',
           title: 'Price Tables',
         },
-        // we probably don't need this
         costCenters: {
+          // deprecated
           type: 'array',
           title: 'Cost Centers',
         },
@@ -105,7 +106,8 @@ export const schemas = [
           format: 'date-time',
         },
       },
-      'v-indexed': ['name', 'status'],
+      'v-indexed': ['name', 'status', 'created'],
+      'v-immediate-indexing': true,
       'v-cache': false,
     },
   },
@@ -132,6 +134,7 @@ export const schemas = [
         },
       },
       'v-indexed': ['name', 'organization'],
+      'v-immediate-indexing': true,
       'v-cache': false,
     },
   },

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -543,16 +543,6 @@ export const resolvers = {
             schema: COST_CENTER_SCHEMA_VERSION,
           })
 
-          // update organization with cost center ID
-          await masterdata.updatePartialDocument({
-            id: organizationId,
-            dataEntity: ORGANIZATION_DATA_ENTITY,
-            fields: {
-              costCenters: [createCostCenterResult.DocumentId],
-            },
-            schema: ORGANIZATION_SCHEMA_VERSION,
-          })
-
           // get roleId of org admin
           const roles = await graphQLServer
             .query(
@@ -755,20 +745,10 @@ export const resolvers = {
           organization: organizationId,
         }
 
-        const createCostCenterResult = await masterdata.createDocument({
+        await masterdata.createDocument({
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: costCenter,
           schema: COST_CENTER_SCHEMA_VERSION,
-        })
-
-        // update organization with cost center ID
-        masterdata.updatePartialDocument({
-          id: organizationId,
-          dataEntity: ORGANIZATION_DATA_ENTITY,
-          fields: {
-            costCenters: [createCostCenterResult.DocumentId],
-          },
-          schema: ORGANIZATION_SCHEMA_VERSION,
         })
 
         message({ graphQLServer, logger, mail }).organizationCreated(name)
@@ -834,23 +814,6 @@ export const resolvers = {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: costCenter,
           schema: COST_CENTER_SCHEMA_VERSION,
-        })
-
-        const organization: Organization = await masterdata.getDocument({
-          dataEntity: ORGANIZATION_DATA_ENTITY,
-          id: organizationId,
-          fields: ORGANIZATION_FIELDS,
-        })
-
-        const costCenterArray = organization.costCenters
-
-        costCenterArray.push(createCostCenterResult.DocumentId)
-
-        await masterdata.updatePartialDocument({
-          dataEntity: ORGANIZATION_DATA_ENTITY,
-          id: organizationId,
-          fields: { costCenters: costCenterArray },
-          schema: ORGANIZATION_SCHEMA_VERSION,
         })
 
         return {
@@ -994,9 +957,6 @@ export const resolvers = {
       const {
         clients: { masterdata },
       } = ctx
-
-      // TODO: remove cost center from organization
-      // or just remove the costCenters array from the organization entity, probably don't need it
 
       try {
         await masterdata.deleteDocument({


### PR DESCRIPTION
#### What problem is this solving?

Enables newly created organizations, organization requests, cost centers, and changes to any of the above to be immediately visible in their respective UIs.

Also deprecates the `costCenters` array in each organization data entity as this is unnecessary. Instead, to get an organization's cost centers, apps can use the `getCostCentersByOrganizationId` query.

#### How to test it?

Linked in https://quotes--sandboxusdev.myvtex.com