### PR TITLE
[B2BORG-19] Send email when org status changes, remove app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Organization admins will be notified via email if an organization's status changes
+
+### Fixed
+
+- App no longer stores data in AppSettings, to allow app to function without being explicitly installed
+
 ## [0.8.1] - 2021-12-17
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -36,9 +36,6 @@
       "name": "read-workspace-apps"
     },
     {
-      "name": "update-app-settings"
-    },
-    {
       "name": "vtex.graphql-server:resolve-graphql"
     },
     {
@@ -46,6 +43,9 @@
     },
     {
       "name": "send-message"
+    },
+    {
+      "name": "vbase-read-write"
     },
     {
       "name": "outbound-access",

--- a/node/assets/organizationStatusChange.html
+++ b/node/assets/organizationStatusChange.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:o="urn:schemas-microsoft-com:office:office"
+  xmlns:v="urn:schemas-microsoft-com:vml"
+  style="
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    background: #f1f1f1 !important;
+  "
+>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{_accountInfo.TradingName}}</title>
+    <!--[if gte mso 9]>
+      <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG />
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+      </xml>
+    <![endif]-->
+    <style>
+      a[x-apple-data-detectors] {
+        color: inherit !important;
+        text-decoration: none !important;
+        font-size: inherit !important;
+        font-family: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+      }
+    </style>
+    <style>
+      @media (max-width: 600px) {
+        img {
+          max-width: 100% !important;
+          height: auto !important;
+        }
+      }
+    </style>
+    <style>
+      @media screen and (min-width: 30em) {
+        .ph4-ns {
+          padding-left: 2rem !important;
+          padding-right: 2rem !important;
+        }
+
+        .mv4-ns {
+          margin-top: 2rem !important;
+          margin-bottom: 2rem !important;
+        }
+      }
+    </style>
+  </head>
+
+  <body
+    style="
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      background: #f1f1f1 !important;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Helvetica, Arial, sans-serif;
+    "
+  >
+    <table
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      style="
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+        background: #f1f1f1;
+        border-collapse: collapse;
+        border-spacing: 0;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          Helvetica, Arial, sans-serif;
+        width: 100%;
+        height: 100%;
+        line-height: 100% !important;
+        color: #000;
+      "
+    >
+      <tr style="box-sizing: border-box !important;">
+        <td
+          align="left"
+          valign="top"
+          style="
+            font-size: 14px;
+            line-height: 20px;
+            box-sizing: border-box;
+            border-collapse: collapse;
+            text-align: left !important;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+              Helvetica, Arial, sans-serif;
+          "
+        >
+          <table
+            class="mv4-ns"
+            width="100%"
+            align="center"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            style="
+              box-sizing: border-box;
+              max-width: 40rem;
+              width: 100%;
+              background-color: #fff;
+              border-collapse: collapse;
+              border-spacing: 0;
+              mso-table-lspace: 0pt;
+              mso-table-rspace: 0pt !important;
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                Helvetica, Arial, sans-serif;
+              color: #000;
+            "
+            bgcolor="#fff"
+          >
+            <tr style="box-sizing: border-box !important;">
+              <td
+                class="ph4-ns"
+                style="
+                  font-size: 14px;
+                  line-height: 20px;
+                  box-sizing: border-box;
+                  border-collapse: collapse;
+                  border-bottom-style: solid;
+                  border-bottom-width: 1px;
+                  border-color: #eee;
+                  width: 100%;
+                  padding-bottom: 2rem;
+                  text-align: left !important;
+                  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                    Roboto, Helvetica, Arial, sans-serif;
+                "
+              >
+                <h1
+                  style="
+                    margin: 1em 0 0;
+                    font-size: 22px;
+                    line-height: 32px;
+                    box-sizing: border-box !important;
+                    color: #000;
+                  "
+                >
+                  Your organization's status has changed.
+                </h1>
+
+                <p>
+                  Hello,
+                  <strong>{{organization.admin}}</strong>.
+                </p>
+                <p>
+                  The status of the
+                  <strong>{{organization.name}}</strong>
+                  organization on {{_accountInfo.TradingName}} has changed. The
+                  status is now <strong>{{organization.status}}</strong>.
+                </p>
+                <p>
+                  Please contact the store's administrator with any
+                  questions.<br />
+                </p>
+              </td>
+            </tr>
+            <tr style="box-sizing: border-box !important;">
+              <td
+                class="ph4-ns"
+                style="
+                  font-size: 14px;
+                  line-height: 20px;
+                  box-sizing: border-box;
+                  border-collapse: collapse;
+                  text-align: left;
+                  border-top-style: solid;
+                  border-top-width: 1px;
+                  border-color: #eee;
+                  padding-top: 1rem;
+                  padding-bottom: 1rem !important;
+                  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                    Roboto, Helvetica, Arial, sans-serif;
+                "
+                align="left"
+              >
+                <p style="box-sizing: border-box !important;">
+                  Regards,<br />
+                  {{_accountInfo.CompanyName}}
+                </p>
+              </td>
+            </tr>
+          </table>
+          <!-- // End Module: Standard Content \\ -->
+        </td>
+      </tr>
+    </table>
+    <!-- // End Template Body \\ -->
+
+    <br />
+  </body>
+</html>

--- a/node/clients/email.ts
+++ b/node/clients/email.ts
@@ -20,11 +20,11 @@ export default class MailClient extends JanusClient {
     })
   }
 
-  // public getTemplate(name: string) {
-  //   return this.http.get<Template>(`${TEMPLATE_RENDER_PATH}/${name}`, {
-  //     metric: 'mail-get-template',
-  //   })
-  // }
+  public getTemplate(name: string) {
+    return this.http.get<Template>(`${TEMPLATE_RENDER_PATH}/${name}`, {
+      metric: 'mail-get-template',
+    })
+  }
 
   public publishTemplate(template: Template) {
     return this.http.post(TEMPLATE_RENDER_PATH, template, {

--- a/node/clients/email.ts
+++ b/node/clients/email.ts
@@ -46,6 +46,7 @@ export interface JsonData {
     name: string
     admin?: string
     note?: string
+    status?: string
   }
 }
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -50,8 +50,4 @@ export default new Service<Clients, RecorderState, ParamsContext>({
     schemaDirectives,
   },
   routes: resolvers.Routes,
-  events: {
-    onAppInstalled: resolvers.Events.createDefaultTemplate,
-    onAppLinked: resolvers.Events.createDefaultTemplate,
-  },
 })

--- a/node/resolvers/message.ts
+++ b/node/resolvers/message.ts
@@ -1,14 +1,18 @@
 /* eslint-disable max-params */
+import type { Logger } from '@vtex/api'
+
 import { QUERIES } from '.'
+import type MailClient from '../clients/email'
+import type { GraphQLServer } from '../clients/graphqlServer'
 
 const getUsers = async (
-  graphQLServer: any,
+  graphQLServer: GraphQLServer,
   roleSlug: string,
-  orgId?: string
+  organizationId?: string
 ) => {
   const {
     data: { listRoles },
-  } = await graphQLServer.query(
+  }: any = await graphQLServer.query(
     QUERIES.listRoles,
     {},
     {
@@ -29,7 +33,7 @@ const getUsers = async (
     QUERIES.listUsers,
     {
       roleId: role.id,
-      ...(orgId && { orgId }),
+      ...(organizationId && { organizationId }),
     },
     {
       persistedQuery: {
@@ -42,7 +46,15 @@ const getUsers = async (
   return listUsers
 }
 
-const message = ({ graphQLServer, logger, mail }: any) => {
+const message = ({
+  graphQLServer,
+  logger,
+  mail,
+}: {
+  graphQLServer: GraphQLServer
+  logger: Logger
+  mail: MailClient
+}) => {
   const organizationCreated = async (name: string) => {
     let users = []
 

--- a/node/service.json
+++ b/node/service.json
@@ -24,15 +24,5 @@
       "path": "/b2b/oms/user/orders/:orderId",
       "public": true
     }
-  },
-  "events": {
-    "onAppInstalled": {
-      "sender": "apps",
-      "keys": ["setup"]
-    },
-    "onAppLinked": {
-      "sender": "apps",
-      "keys": ["linked", "relinked"]
-    }
   }
 }

--- a/node/templates/index.ts
+++ b/node/templates/index.ts
@@ -1,11 +1,13 @@
 import { organizationAcceptedMessage } from './organizationAccepted'
 import { organizationCreatedMessage } from './organizationCreated'
 import { organizationDeclinedMessage } from './organizationDeclined'
+import { organizationStatusChangedMessage } from './organizationStatusChanged'
 
 const templates = [
   organizationCreatedMessage,
   organizationAcceptedMessage,
   organizationDeclinedMessage,
+  organizationStatusChangedMessage,
 ]
 
 export default templates

--- a/node/templates/organizationStatusChanged.ts
+++ b/node/templates/organizationStatusChanged.ts
@@ -1,0 +1,38 @@
+import readFile from '../utils/readFile'
+
+const MESSAGE_BODY = readFile('../assets/organizationStatusChange.html')
+
+export const organizationStatusChangedMessage = {
+  Name: 'organization-status-changed',
+  FriendlyName: 'Organization Status Changed',
+  // Description: null,
+  IsDefaultTemplate: false,
+  // AccountId: null,
+  // AccountName: null,
+  // ApplicationId: null,
+  IsPersisted: true,
+  IsRemoved: false,
+  Type: '',
+  Templates: {
+    email: {
+      To: '{{message.to}}',
+      // CC: null,
+      // BCC: null,
+      Subject: 'Organization Status Change',
+      Message: MESSAGE_BODY,
+      Type: 'E',
+      ProviderId: '00000000-0000-0000-0000-000000000000',
+      // ProviderName: null,
+      IsActive: true,
+      withError: false,
+    },
+    sms: {
+      Type: 'S',
+      // ProviderId: null,
+      // ProviderName: null,
+      IsActive: false,
+      withError: false,
+      Parameters: [],
+    },
+  },
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds a new email template for organization status changes. When an organization's status is changed, any `customer-admin`s assigned to the organization will be notified. 

Also, previous version relied on AppSettings to store data about MD schemas. Dependency apps can't have app settings, so this logic has been removed and replaced with VBASE. This will allow the app to function properly without being explicitly installed in a workspace.

#### How to test it?

Linked in https://quotes--sandboxusdev.myvtex.com
Assign yourself as a customer-admin of an organization and then change the organization's status. You should receive an email.