### PR TITLE
[B2BORG-45] Fix GraphQL bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Correctly handle spaces when searching masterdata
 - Use CL id instead of user id in `saveUser` and `removeUser` operations
 
 ## [0.9.1] - 2022-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use CL id instead of user id in `saveUser` and `removeUser` operations
+
 ## [0.9.1] - 2022-01-06
+
+### Added
+
+- SonarCloud PR integration
 
 ## [0.9.0] - 2021-12-23
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -101,7 +101,7 @@ type Mutation {
     name: String!
     email: String!
   ): MutationResponse @withSession @withPermissions
-  removeUser(id: ID!, userId: ID, email: String!): MutationResponse
+  removeUser(id: ID!, userId: ID, email: String!, clId: ID!): MutationResponse
     @withSession
     @withPermissions
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -232,15 +232,15 @@ const getUserRoleSlug = async (id: string, ctx: Context) => {
       )
     })
     .then((result: any) => {
-      return result.data.getRole.slug
+      return result?.data?.getRole?.slug ?? ''
     })
     .catch((error: any) => {
-      logger.error({
+      logger.warn({
         message: 'getUserRoleSlug-error',
         error,
       })
 
-      return { status: 'error', message: error }
+      return ''
     })
 }
 
@@ -1058,9 +1058,9 @@ export const resolvers = {
         throw new GraphQLError('operation-not-permitted')
       }
 
-      if (id) {
+      if (clId) {
         // check the role of the user to be saved
-        const roleSlug = await getUserRoleSlug(id, ctx)
+        const roleSlug = await getUserRoleSlug(clId, ctx)
 
         // organization admin can only save organization users
         if (roleSlug.indexOf('sales') !== -1) {
@@ -1068,7 +1068,7 @@ export const resolvers = {
         }
       } else {
         // check the role of the user being added
-        const roleSlug = await graphQLServer
+        const roleSlug: string = await graphQLServer
           .query(
             QUERIES.getRole,
             { id: roleId },
@@ -1080,15 +1080,15 @@ export const resolvers = {
             }
           )
           .then((result: any) => {
-            return result.data.getRole.slug
+            return result?.data?.getRole?.slug ?? ''
           })
           .catch((error: any) => {
-            logger.error({
+            logger.warn({
               message: 'saveUser-getRoleError',
               error,
             })
 
-            return { status: 'error', message: error }
+            return ''
           })
 
         // organization admin can only add organization users
@@ -1125,7 +1125,7 @@ export const resolvers = {
     },
     removeUser: async (
       _: any,
-      { id, userId, email }: UserArgs,
+      { id, userId, email, clId }: UserArgs,
       ctx: Context
     ) => {
       const {
@@ -1134,7 +1134,7 @@ export const resolvers = {
         vtex: { adminUserAuthToken, logger },
       } = ctx
 
-      if (!id || !userId || !email) {
+      if (!id || !clId || !email) {
         throw new GraphQLError('user-information-not-provided')
       }
 
@@ -1160,7 +1160,7 @@ export const resolvers = {
       }
 
       // check the role of the user to be removed
-      const roleSlug = await getUserRoleSlug(id, ctx)
+      const roleSlug = await getUserRoleSlug(clId, ctx)
 
       // organization admin can only remove organization users
       if (roleSlug.indexOf('sales') !== -1) {
@@ -1350,7 +1350,7 @@ export const resolvers = {
       }
 
       if (search) {
-        whereArray.push(`name=*${encodeURI(search)}*`)
+        whereArray.push(`name="*${search}*"`)
       }
 
       const where = whereArray.join(' AND ')

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1247,7 +1247,7 @@ export const resolvers = {
       }
 
       if (search) {
-        whereArray.push(`name=*${encodeURI(search)}*`)
+        whereArray.push(`name="*${search}*"`)
       }
 
       const where = whereArray.join(' AND ')
@@ -1490,7 +1490,7 @@ export const resolvers = {
       let where = ''
 
       if (search) {
-        where = `name=*${encodeURI(search)}*`
+        where = `name="*${search}*"`
       }
 
       try {
@@ -1547,7 +1547,7 @@ export const resolvers = {
       let where = `organization=${id}`
 
       if (search) {
-        where += ` AND name=*${encodeURI(search)}*`
+        where += ` AND name="*${search}*"`
       }
 
       try {
@@ -1620,7 +1620,7 @@ export const resolvers = {
       let where = `organization=${id}`
 
       if (search) {
-        where += ` AND name=*${encodeURI(search)}*`
+        where += ` AND name="*${search}*"`
       }
 
       try {


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes two main bugs reported by the BitCot QA team:

- organization admin was previously unable to edit or remove users in their organization
- searching for organizations, cost centers, or organization requests with spaces in their names was not possible

The solution to the first issue was to make sure the user's CL ID is being passed to the mutation. There will be a related PR opened in `vtex.b2b-organizations` to address the frontend side of this as well.

The solution to the second issue was to surround the search term in quotes when constructing the `where` clause for Masterdata.

#### How to test it?

App is currently linked in https://quotes--sandboxusdev.myvtex.com 