### PR TITLE
[B2BORG-25][B2BORG-74] Add impersonation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `impersonateUser` mutation
+- Permission checks related to sales roles
+
+### Changed
+
+- Increase timeout
+
+### Fixed
+
+- `checkConfig` promise bug that prevented MD schema from being created
+
 ## [0.9.2] - 2022-01-26
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -22,7 +22,6 @@ type Query {
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
-    @withPermissions
     @cacheControl(scope: PRIVATE)
   getCostCenters(
     search: String
@@ -46,19 +45,14 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): CostCenterResult
-    @withSession
-    @withPermissions
-    @cacheControl(scope: PRIVATE)
+  ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
-    @withPermissions
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getUsers(organizationId: ID, costCenterId: ID): [B2BUser]
     @withSession
-    @withPermissions
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getPaymentTerms: [PaymentTerm] @cacheControl(scope: PUBLIC, maxAge: SHORT)
 }
@@ -102,6 +96,9 @@ type Mutation {
     email: String!
   ): MutationResponse @withSession @withPermissions
   removeUser(id: ID!, userId: ID, email: String!, clId: ID!): MutationResponse
+    @withSession
+    @withPermissions
+  impersonateUser(clId: ID, userId: ID): MutationResponse
     @withSession
     @withPermissions
 }

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,0 +1,89 @@
+export const QUERIES = {
+  getPermission: `query permissions {
+      checkUserPermission @context(provider: "vtex.storefront-permissions"){
+        role {
+          id
+          name
+          slug
+        }
+        permissions
+      }
+    }`,
+  listUsers: `query users($organizationId: ID, $costCenterId: ID, $roleId: ID) {
+      listUsers(organizationId: $organizationId, costCenterId: $costCenterId, roleId: $roleId) @context(provider: "vtex.storefront-permissions") {
+        id
+        roleId
+        userId
+        clId
+        orgId
+        costId
+        name
+        email
+        canImpersonate
+      }
+    }`,
+  listRoles: `query roles {
+      listRoles @context(provider: "vtex.storefront-permissions") {
+        id
+        name
+        slug
+      }
+    }`,
+  getUser: `query user($id: ID!) {
+      getUser(id: $id) @context(provider: "vtex.storefront-permissions") {
+        id
+        roleId
+        userId
+        clId
+        orgId
+        costId
+        name
+        email
+        canImpersonate
+      }
+    }`,
+  getRole: `query role($id: ID!) {
+      getRole(id: $id) @context(provider: "vtex.storefront-permissions") {
+        id
+        name
+        slug
+      }
+    }`,
+  checkImpersonation: `query checkImpersonation {
+      checkImpersonation @context(provider: "vtex.storefront-permissions") {
+        firstName
+        lastName
+        email
+        userId
+        error
+      }
+    }`,
+}
+
+export const MUTATIONS = {
+  saveUser: `mutation saveUser($id: ID, $roleId: ID!, $userId: ID, $orgId: ID, $costId: ID, $clId: ID, $canImpersonate: Boolean, $name: String!, $email: String!) {
+      saveUser(id: $id, roleId: $roleId, userId: $userId, orgId: $orgId, costId: $costId, clId: $clId, canImpersonate: $canImpersonate, name: $name, email: $email) @context(provider: "vtex.storefront-permissions") {
+        id
+        status
+        message
+      }
+    }`,
+  deleteUser: `mutation deleteUser($id: ID!, $userId: ID, $email: String!) {
+      deleteUser(id: $id, userId: $userId, email: $email) @context(provider: "vtex.storefront-permissions") {
+        id
+        status
+        message
+      }
+    }`,
+  impersonateUser: `mutation impersonateUser($userId: ID) {
+        impersonateUser(userId: $userId) @context(provider: "vtex.storefront-permissions") {
+            id
+            status
+            message
+        }
+    }`,
+}
+
+export const CONNECTOR = {
+  PROMISSORY: 'Vtex.PaymentGateway.Connectors.PromissoryConnector',
+} as const

--- a/node/index.ts
+++ b/node/index.ts
@@ -10,7 +10,7 @@ import { Clients } from './clients'
 import { schemaDirectives } from './resolvers/directives'
 import { resolvers } from './resolvers'
 
-const TIMEOUT_MS = 3000
+const TIMEOUT_MS = 4000
 
 // Create a LRU memory cache for the Status client.
 // The @vtex/api HttpClient respects Cache-Control headers and uses the provided cache.

--- a/node/resolvers/directives/withPermissions.ts
+++ b/node/resolvers/directives/withPermissions.ts
@@ -24,7 +24,7 @@ export class WithPermissions extends SchemaDirectiveVisitor {
     field.resolve = async (root: any, args: any, context: any, info: any) => {
       const {
         clients: { graphQLServer },
-        vtex: { logger },
+        vtex: { adminUserAuthToken, logger },
       } = context
 
       context.vtex.storefrontPermissions = await graphQLServer
@@ -39,14 +39,18 @@ export class WithPermissions extends SchemaDirectiveVisitor {
           }
         )
         .then((result: any) => {
-          return result.data.checkUserPermission
+          return result?.data?.checkUserPermission ?? null
         })
         .catch((error: any) => {
           console.error(error)
-          logger.error({
-            message: 'getPermissionsError',
-            error,
-          })
+          if (!adminUserAuthToken) {
+            logger.error({
+              message: 'getPermissionsError',
+              error,
+            })
+          }
+
+          return null
         })
 
       return resolve(root, args, context, info)

--- a/node/resolvers/message.ts
+++ b/node/resolvers/message.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-params */
 import type { Logger } from '@vtex/api'
 
-import { QUERIES } from '.'
+import { QUERIES } from '../constants'
 import type MailClient from '../clients/email'
 import type { GraphQLServer } from '../clients/graphqlServer'
 


### PR DESCRIPTION
#### What problem is this solving?

To support user impersonation, this PR adds a mutation which checks the user's permissions before forwarding the request to `storefront-permissions`.  

Also, this fixes a bug in the `checkConfig` function that was preventing the app from creating MD schema when installed in a new account. 

#### How should this be manually tested?

This new version along with new versions of `b2b-organizations` and `storefront-permissions` is linked here: https://b2bsuite--sandboxusdev.myvtex.com/

To impersonate a user, login as someone with impersonation permissions (i.e. a sales role or org admin), then go to My Organization and click the three dots next to a user in the user list.