### PR TITLE
[B2BORG-83] Allow all payment methods to be assigned to orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Adjust `getPaymentTerms` query so that it now returns all enabled payment methods, not just promissories
+
+### Fixed
+
+- In the `orders` route handler, request the user's permissions for `vtex.b2b-orders-history` instead of `vtex.b2b-organizations`
+
 ## [0.11.0] - 2022-03-24
 
 ### Fixed

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -92,7 +92,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     super('vtex.storefront-permissions@1.x', ctx, options)
   }
 
-  public checkUserPermission = async (): Promise<any> => {
+  public checkUserPermission = async (app?: string): Promise<any> => {
     return this.graphql.query(
       {
         query: QUERIES.getPermission,
@@ -100,7 +100,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: app ?? 'vtex.b2b-organizations@0.x',
           },
         },
       },

--- a/node/constants.ts
+++ b/node/constants.ts
@@ -1,3 +1,22 @@
-export const CONNECTOR = {
+export const PROMISSORY_CONNECTOR = {
   PROMISSORY: 'Vtex.PaymentGateway.Connectors.PromissoryConnector',
 } as const
+
+export const CREDIT_CARDS = [
+  'Visa',
+  'Mastercard',
+  'Diners',
+  'American Express',
+  'Hipercard',
+  'Discover',
+  'Aura',
+  'Elo',
+  'Banricompras',
+  'JCB',
+  'Cabal',
+  'Nativa',
+  'Naranja',
+  'Nevada',
+  'Shopping',
+  'Credz',
+]

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ForbiddenError } from '@vtex/api'
 
-// import { CONNECTOR } from '../constants'
 import {
   schemas,
   ORGANIZATION_REQUEST_DATA_ENTITY,
@@ -20,6 +19,7 @@ import GraphQLError from '../utils/GraphQLError'
 import { organizationName, costCenterName, role } from './fieldResolvers'
 import message from './message'
 import templates from '../templates'
+import { CREDIT_CARDS } from '../constants'
 
 interface Settings {
   schemaHash: string | null
@@ -1779,26 +1779,7 @@ export const resolvers = {
 
         const uniquePaymentSystemsWithoutCreditCards = uniquePaymentSystems.filter(
           value => {
-            const creditCards = [
-              'Visa',
-              'Mastercard',
-              'Diners',
-              'American Express',
-              'Hipercard',
-              'Discover',
-              'Aura',
-              'Elo',
-              'Banricompras',
-              'JCB',
-              'Cabal',
-              'Nativa',
-              'Naranja',
-              'Nevada',
-              'Shopping',
-              'Credz',
-            ]
-
-            return !creditCards.includes(value.name)
+            return !CREDIT_CARDS.includes(value.name)
           }
         )
 


### PR DESCRIPTION
### What problem is this solving?

Our team recently decided that when assigning payment terms to an organization, any of the store's payment methods should be eligible for assignment. Until now, we have only been allowing Promissory payment types to be assigned. This PR alters the getPaymentTerms query so that all enabled payment methods are available for assignment.

For credit cards (Visa, Mastercard, etc), the app filters these out of the list and adds a generic "Credit card" entry to the array instead. This is because all credit cards in checkout are combined into a single "Credit card" option.

This PR also fixes an unrelated bug where the wrong app's permissions were being checked in the orders route handler. We need to check the user's permissions for vtex.b2b-orders-history and not their permissions for vtex.b2b-organizations.

### How to test it?

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com/
Check the available payment options here: https://b2bsuite--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/1574d7ea-1250-11ec-82ac-020154316047/