### PR TITLE
[B2BORG-84] Add businessDocument to cost center data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Optional `businessDocument` field for cost centers
+
 ## [0.12.0] - 2022-03-25
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -147,6 +147,7 @@ type B2BUserSimple {
 type DefaultCostCenter {
   name: String
   address: Address
+  businessDocument: String
 }
 
 type Organization {
@@ -176,6 +177,7 @@ type CostCenter {
   organization: ID
   addresses: [Address]
   paymentTerms: [PaymentTerm]
+  businessDocument: String
 }
 
 type Address {
@@ -244,12 +246,14 @@ input B2BUserInput {
 input DefaultCostCenterInput {
   name: String
   address: AddressInput
+  businessDocument: String
 }
 
 input CostCenterInput {
   name: String
   addresses: [AddressInput]
   paymentTerms: [PaymentTermInput]
+  businessDocument: String
 }
 
 input AddressInput {

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -30,8 +30,9 @@ export const COST_CENTER_FIELDS = [
   'addresses',
   'paymentTerms',
   'organization',
+  'businessDocument',
 ]
-export const COST_CENTER_SCHEMA_VERSION = 'v0.0.4'
+export const COST_CENTER_SCHEMA_VERSION = 'v0.0.5'
 
 export const schemas = [
   {
@@ -132,8 +133,12 @@ export const schemas = [
           type: 'string',
           title: 'Organization',
         },
+        businessDocument: {
+          type: 'string',
+          title: 'Business Document',
+        },
       },
-      'v-indexed': ['name', 'organization'],
+      'v-indexed': ['name', 'organization', 'businessDocument'],
       'v-immediate-indexing': true,
       'v-cache': false,
     },

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "0.12.0",
   "dependencies": {
-    "@vtex/api": "6.45.10",
+    "@vtex/api": "6.45.11-beta",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.10",
+    "@vtex/api": "6.45.11-beta",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "tslint": "^5.12.0",

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -455,6 +455,10 @@ export const resolvers = {
             name: organizationRequest.defaultCostCenter.name,
             addresses: [organizationRequest.defaultCostCenter.address],
             organization: organizationId,
+            ...(organizationRequest.defaultCostCenter.businessDocument && {
+              businessDocument:
+                organizationRequest.defaultCostCenter.businessDocument,
+            }),
           }
 
           const createCostCenterResult = await masterdata.createDocument({
@@ -648,6 +652,9 @@ export const resolvers = {
           name: defaultCostCenter.name,
           addresses: [defaultCostCenter.address],
           organization: organizationId,
+          ...(defaultCostCenter.businessDocument && {
+            businessDocument: defaultCostCenter.businessDocument,
+          }),
         }
 
         await masterdata.createDocument({
@@ -682,7 +689,7 @@ export const resolvers = {
       _: void,
       {
         organizationId,
-        input: { name, addresses },
+        input: { name, addresses, businessDocument },
       }: { organizationId: string; input: CostCenterInput },
       ctx: Context
     ) => {
@@ -715,6 +722,7 @@ export const resolvers = {
           name,
           addresses,
           organization: organizationId,
+          ...(businessDocument && { businessDocument }),
         }
 
         const createCostCenterResult = await masterdata.createDocument({
@@ -815,7 +823,7 @@ export const resolvers = {
       _: void,
       {
         id,
-        input: { name, addresses, paymentTerms },
+        input: { name, addresses, paymentTerms, businessDocument },
       }: { id: string; input: CostCenterInput },
       ctx: Context
     ) => {
@@ -833,8 +841,9 @@ export const resolvers = {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
             name,
-            addresses,
-            ...(paymentTerms ? { paymentTerms } : {}),
+            ...(addresses?.length && { addresses }),
+            ...(paymentTerms && { paymentTerms }),
+            ...(businessDocument && { businessDocument }),
           },
         })
 

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -53,12 +53,14 @@ interface B2BCustomerInput {
 interface DefaultCostCenterInput {
   name: string
   address: AddressInput
+  businessDocument?: string
 }
 
 interface CostCenterInput {
   name: string
-  addresses: AddressInput[]
-  paymentTerms: PaymentTerm[]
+  addresses?: AddressInput[]
+  paymentTerms?: PaymentTerm[]
+  businessDocument?: string
 }
 
 interface AddressInput {
@@ -99,6 +101,7 @@ interface CostCenter {
   organization: string
   addresses: any[]
   paymentTerms: PaymentTerm[]
+  businessDocument?: string
 }
 
 interface UserArgs {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -235,10 +235,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.10":
-  version "6.45.10"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.10.tgz#d338d05341e176593124fa171ea5710eee802e61"
-  integrity sha512-1OllEdBosqGbyGSvQtJzplmOISj2jalpgTDhRWlzhCdkGYbAg0Sm4doudKfZdvizu/6D1Dz4Uy2YncT6M3Vzng==
+"@vtex/api@6.45.11-beta":
+  version "6.45.11-beta"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.11-beta.tgz#edc51a2fdd3903f33caf7d63f198005f0d5a0c98"
+  integrity sha512-BFHMWU4SEFKXpbW3TWj0CI944p9ysmoCtB8ewpQlyRpUZFhPx2On/qFgBrD+Gqwt1yvysuKIAOfzfpjqKy88Gg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -259,7 +259,7 @@
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
     graphql-upload "^8.1.0"
-    jaeger-client "^3.18.0"
+    jaeger-client "^3.19.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
     koa-compose "^4.1.0"
@@ -269,7 +269,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^12.0.0"
+    prom-client "^14.0.1"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -1070,16 +1070,16 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
-jaeger-client@^3.18.0:
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.18.1.tgz#a8c7a778244ba117f4fb8775eb6aa5508703564e"
-  integrity sha512-eZLM2U6rJvYo0XbzQYFeMYfp29gQix7SKlmDReorp9hJkUwXZtTyxW81AcKdmFCjLHO5tFysTX+394BnjEnUZg==
+jaeger-client@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.19.0.tgz#9b5bd818ebd24e818616ee0f5cffe1722a53ae6e"
+  integrity sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==
   dependencies:
     node-int64 "^0.4.0"
     opentracing "^0.14.4"
     thriftrw "^3.5.0"
-    uuid "^3.2.1"
-    xorshift "^0.2.0"
+    uuid "^8.3.2"
+    xorshift "^1.1.1"
 
 jest-diff@^27.0.0:
   version "27.2.0"
@@ -1480,10 +1480,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
+  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
   dependencies:
     tdigest "^0.1.1"
 
@@ -1616,7 +1616,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1818,10 +1818,15 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.3:
+uuid@^3.1.0, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1.1.2:
   version "1.1.2"
@@ -1841,10 +1846,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-xorshift@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
-  integrity sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=
+xorshift@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-1.2.0.tgz#30a4cdd8e9f8d09d959ed2a88c42a09c660e8148"
+  integrity sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==
 
 xss@^1.0.6:
   version "1.0.9"


### PR DESCRIPTION
#### What problem is this solving?

Update MD schema and GraphQL schema/resolvers to support an optional `businessDocument` string field within the cost center data model. This field will be used for Brazilian companies to store their CNPJ for each cost center. This PR also allows the `businessDocument` for the default cost center to be specified when an organization request is submitted.

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com

Use GraphiQL to get a cost center by ID, example:
https://b2bsuite--sandboxusdev.myvtex.com/admin/graphql-ide

```
query {
  getCostCenterById(id: "74bc8b61-94ed-11ec-835d-02e7a56b8989") {
    name
    organization
    businessDocument
  }
}
```

or change the businessDocument like so:

```
mutation {
  updateCostCenter(id: "74bc8b61-94ed-11ec-835d-02e7a56b8989", input: { name: "Cost Center 3", businessDocument: "test-business-document"}) {
    status
  message
  }
}
```
