### PR TITLE
[B2BORG-82] Check duplicate requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- add subfield `email` of the `b2bCustomerAdmin` field to check duplicate requests by email
+
 ## [0.14.0] - 2022-04-04
 
 ### Added

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -51,6 +51,12 @@ export const schemas = [
         b2bCustomerAdmin: {
           type: 'object',
           title: 'B2B Customer Admin',
+          properties: {
+            email: {
+              type: 'string',
+            },
+          },
+          'v-indexed': ['email'],
         },
         status: {
           type: 'string',
@@ -66,7 +72,7 @@ export const schemas = [
           format: 'date-time',
         },
       },
-      'v-indexed': ['name', 'status', 'created'],
+      'v-indexed': ['name', 'b2bCustomerAdmin', 'status', 'created'],
       'v-immediate-indexing': true,
       'v-cache': false,
     },

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1389,7 +1389,15 @@ export const resolvers = {
       }
 
       if (search) {
-        whereArray.push(`name="*${search}*"`)
+        if (
+          search.match(
+            /^([a-zA-Z0-9!#$%&'*+=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)$/gm
+          )
+        ) {
+          whereArray.push(`b2bCustomerAdmin.email=${search}`)
+        } else {
+          whereArray.push(`name="*${search}*"`)
+        }
       }
 
       const where = whereArray.join(' AND ')


### PR DESCRIPTION
What problem is this solving?

add subfield `email` of the `b2bCustomerAdmin` field to check duplicate requests by email

How to test it?

test at [https://aurora--sandboxusdev.myvtex.com/_v/private/vtex.b2b-organizations@1.2.2/graphiql/v1](url) 
example :
`query {
  getOrganizationRequests(
    status: ["pending", "approved"],
    search: "aurora.shen@vtex.com.br",
  	page: 1,
  	pageSize: 25,
  	sortOrder: "DESC",
  	sortedBy: "created"){
    data {
      b2bCustomerAdmin {
        firstName
        lastName
        email
      }
    }
 }
}`