### PR TITLE
fix:  Fixed a bug in MutationResponse by adding the "status" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug in MutationResponse by adding the "status" field
+
 ## [0.16.0] - 2022-04-15
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -228,6 +228,7 @@ type Address {
 type MasterDataResponse {
   id: String
   href: String
+  status: String
 }
 
 type MutationResponse {


### PR DESCRIPTION
#### What problem is this solving?

There is a bug on b2b-organizations-graphql on creating the organization request

#### How to test it?

You can test in this URL: [https://b2bartur--productusqa.myvtex.com/organization-request](https://b2bartur--productusqa.myvtex.com/organization-request)
