### PR TITLE
[B2BORDERS-8] New route and permission checks for orders history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Cancellation request route to support `vtex.b2b-orders-history`
+- Checkout client
+- Permission check in `order` route
+
+### Changed
+
+- Use admin OMS API to get order details, to ensure we have the user's email
+
 ## [0.16.1] - 2022-04-25
 
 ### Added
+
 - Added duplicate check for create organization request
 
 ## [0.16.0] - 2022-04-15
 
 ### Added
+
 - the structure of the components has been improved;
 - Added 2 mutations in order to follow the mutations from storefront permissions (updateUser and addUser);
 
 ### Fixed
+
 - Remove a couple of conditionals nested;
 - Remove unnecessary variables, some changes to inline returns;
 
@@ -33,10 +46,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 Added 2 mutations to handle the cost center addresses
+
 - updateCostCenterAddress
 - createCostCenterAddress
-see schema/schema.graphql for more details
-
+  see schema/schema.graphql for more details
 
 ## [0.13.0] - 2022-03-31
 

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,12 @@
       "name": "OMSViewer"
     },
     {
+      "name": "AcessaTodosPedidos"
+    },
+    {
+      "name": "CancelaPedidos"
+    },
+    {
       "name": "ViewPayments"
     },
     {

--- a/node/clients/Oms.ts
+++ b/node/clients/Oms.ts
@@ -3,7 +3,7 @@ import { JanusClient } from '@vtex/api'
 
 import { statusToError } from '../utils'
 
-export class OMSClient extends JanusClient {
+export default class OMSClient extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(ctx, {
       ...options,
@@ -32,7 +32,7 @@ export class OMSClient extends JanusClient {
     const base = '/api/oms'
 
     return {
-      order: (id: string) => `${base}/pvt/orders/${id}`,
+      order: (id: string) => `${base}/pvt/admin/orders/${id}`,
       search: (query: string) => `${base}/pvt/orders?${query}`,
     }
   }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -1,0 +1,30 @@
+import type { IOContext, InstanceOptions } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+export default class Checkout extends JanusClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, { ...options })
+  }
+
+  public async requestCancellation(orderId: string) {
+    return this.http.postRaw(
+      `${this.routes.requestCancellation(orderId)}`,
+      {},
+      {
+        headers: {
+          VtexIdclientAutCookie: this.context.authToken,
+        },
+        metric: 'checkout-requestCancellation',
+      }
+    )
+  }
+
+  private get routes() {
+    const basePvt = '/api/checkout/pvt'
+
+    return {
+      requestCancellation: (orderId: string) =>
+        `${basePvt}/orders/${orderId}/cancelation-request`,
+    }
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -3,13 +3,14 @@ import { IOClients } from '@vtex/api'
 import VtexId from './vtexId'
 import PaymentsClient from './payments'
 import MailClient from './email'
-import { OMSClient } from './Oms'
+import Checkout from './checkout'
+import OMSClient from './Oms'
 import StorefrontPermissions from './storefrontPermissions'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
-  public get vtexId() {
-    return this.getOrSet('vtexId', VtexId)
+  public get checkout() {
+    return this.getOrSet('checkout', Checkout)
   }
 
   public get payments() {
@@ -26,5 +27,9 @@ export class Clients extends IOClients {
 
   public get storefrontPermissions() {
     return this.getOrSet('storefrontPermissions', StorefrontPermissions)
+  }
+
+  public get vtexId() {
+    return this.getOrSet('vtexId', VtexId)
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "0.16.1",
   "dependencies": {
-    "@vtex/api": "6.45.11-beta",
+    "@vtex/api": "6.45.12",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -19,7 +19,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.11-beta",
+    "@vtex/api": "6.45.12",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "tslint": "^5.12.0",

--- a/node/service.json
+++ b/node/service.json
@@ -23,6 +23,10 @@
     "order": {
       "path": "/b2b/oms/user/orders/:orderId",
       "public": true
+    },
+    "requestCancellation": {
+      "path": "/b2b/checkout/pub/orders/:orderId/user-cancel-request",
+      "public": true
     }
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -193,10 +193,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.11-beta":
-  version "6.45.11-beta"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.11-beta.tgz#edc51a2fdd3903f33caf7d63f198005f0d5a0c98"
-  integrity sha512-BFHMWU4SEFKXpbW3TWj0CI944p9ysmoCtB8ewpQlyRpUZFhPx2On/qFgBrD+Gqwt1yvysuKIAOfzfpjqKy88Gg==
+"@vtex/api@6.45.12":
+  version "6.45.12"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
+  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -217,7 +217,7 @@
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
     graphql-upload "^8.1.0"
-    jaeger-client "^3.19.0"
+    jaeger-client "^3.18.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
     koa-compose "^4.1.0"
@@ -227,7 +227,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^14.0.1"
+    prom-client "^12.0.0"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -1024,7 +1024,7 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
-jaeger-client@^3.19.0:
+jaeger-client@^3.18.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.19.0.tgz#9b5bd818ebd24e818616ee0f5cffe1722a53ae6e"
   integrity sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==
@@ -1438,10 +1438,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
-  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
+prom-client@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
+  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
   dependencies:
     tdigest "^0.1.1"
 
@@ -1575,7 +1575,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Adds a permission check to the app's `order` route to ensure that the frontend user has permission to view the order in question. Also the app now uses the admin version of the OMS API to get the order details, because this API returns the shopper's actual email inside the `clientProfileData` object, instead of a masked version. We need this email to check in `b2b-order-history` if the current user was the one who placed the order.

Also adds a new route for order cancellation requests since normally the frontend user is only able to request the cancellation of an order that they personally placed. This route uses the app's credential (and the `CancelaPedidos` policy) to submit the cancellation request using checkout's private API route, after first ensuring that the user has permissions to do so (i.e. they are part of the same organization as the user who placed the order). 

#### How to test it?

This new version and a new version of `b2b-orders-history` are both linked in http://b2bsuite--sandboxusdev.myvtex.com

Log in as an organization user, go to My Account -> Orders (there are two Orders links, choose the second one) and try viewing and cancelling an order. Also try changing the URL to an order ID that you should not be able to access.
