### PR TITLE
[B2BORG-29] Highlight organizations without sales managers assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the query to get the organizations without a sales manager
+
 ## [0.17.0] - 2022-05-23
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -18,6 +18,10 @@ type Query {
     sortOrder: String = "ASC"
     sortedBy: String = "name"
   ): OrganizationResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
+
+  getOrganizationsWithoutSalesManager: [Organization]
+    @cacheControl(scope: PRIVATE)
+
   getOrganizationById(id: ID): Organization
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
   getOrganizationByIdStorefront(id: ID): Organization

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -12,6 +12,15 @@ export const QUERIES = {
       permissions
     }
   }`,
+  listAllUsers: `query users {
+    listAllUsers {
+      id
+      orgId
+      costId
+      name
+      email      
+    }
+  }`,
   listUsers: `query users($organizationId: ID, $costCenterId: ID, $roleId: ID) {
     listUsers(organizationId: $organizationId, costCenterId: $costCenterId, roleId: $roleId) {
       id
@@ -164,6 +173,22 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       {
         query: QUERIES.getRole,
         variables: { id: roleId },
+        extensions: {
+          persistedQuery: {
+            provider: 'vtex.storefront-permissions@1.x',
+            sender: 'vtex.b2b-organizations@0.x',
+          },
+        },
+      },
+      {}
+    )
+  }
+
+  public listAllUsers = async (): Promise<any> => {
+    return this.graphql.query(
+      {
+        query: QUERIES.listAllUsers,
+        variables: {},
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -237,15 +237,15 @@ const Organizations = {
       return await masterdata.searchDocumentsWithPaginationInfo({
         dataEntity: ORGANIZATION_REQUEST_DATA_ENTITY,
         fields: ORGANIZATION_REQUEST_FIELDS,
-        schema: ORGANIZATION_REQUEST_SCHEMA_VERSION,
         pagination: { page, pageSize },
+        schema: ORGANIZATION_REQUEST_SCHEMA_VERSION,
         sort: `${sortedBy} ${sortOrder}`,
         ...(where && { where }),
       })
     } catch (e) {
       logger.error({
-        message: 'getOrganizationRequests-error',
         error: e,
+        message: 'getOrganizationRequests-error',
       })
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/resolvers/Queries/index.ts
+++ b/node/resolvers/Queries/index.ts
@@ -1,9 +1,103 @@
-import { schemas } from '../../mdSchema'
+import {
+  ORGANIZATION_DATA_ENTITY,
+  ORGANIZATION_FIELDS,
+  ORGANIZATION_SCHEMA_VERSION,
+  schemas,
+} from '../../mdSchema'
 import { toHash } from '../../utils'
 import GraphQLError from '../../utils/GraphQLError'
 import { getAppId } from '../config'
 import CostCenters from './CostCenters'
 import Organizations from './Organizations'
+
+const SCROLL_AWAIT_TIME = 100
+const SLEEP_ADD_PERCENTAGE = 0.1
+const SCROLL_SIZE = 1000
+/**
+ * Checks the permissions by applying the following rules:
+ * @param checkUserPermission
+ */
+const isSalesAdmin = (checkUserPermission: any) =>
+  checkUserPermission?.role.slug.match(/sales-admin/) || false
+
+const getCheckUserPermission = async ({
+  storefrontPermissions,
+  logger,
+}: any) => {
+  const {
+    data: { checkUserPermission },
+  }: any = await storefrontPermissions
+    .checkUserPermission('vtex.b2b-organizations@1.x')
+    .catch((error: any) => {
+      logger.error({
+        error,
+        message: 'checkUserPermission-error',
+      })
+
+      return {
+        data: {
+          checkUserPermission: null,
+        },
+      }
+    })
+
+  return checkUserPermission
+}
+
+/**
+ * Checks the user permissions and returns the organizationId updated
+ * @param validateUserAdmin
+ * @param vtex
+ * @param storefrontPermissions
+ * @param adminUserAuthToken
+ * @param organizationId
+ * @param logger
+ */
+const checkUserPermissions = async ({
+  validateUserAdmin,
+  vtex,
+  storefrontPermissions,
+  adminUserAuthToken,
+  organizationId,
+  logger,
+}: any) => {
+  const { sessionData } = vtex as any
+  const { checkUserPermission } = await getCheckUserPermission({
+    logger,
+    storefrontPermissions,
+  })
+
+  const condition = validateUserAdmin
+    ? !adminUserAuthToken && !isSalesAdmin(checkUserPermission)
+    : !adminUserAuthToken
+
+  if (condition) {
+    if (!sessionData?.namespaces['storefront-permissions']) {
+      throw new GraphQLError('organization-data-not-found')
+    }
+
+    const {
+      organization: { value: userOrganizationId },
+    } = sessionData?.namespaces['storefront-permissions']
+
+    if (!organizationId) {
+      // get user's organization from session
+      organizationId = userOrganizationId
+    }
+
+    if (organizationId !== userOrganizationId) {
+      throw new GraphQLError('operation-not-permitted')
+    }
+  }
+
+  return { organizationId }
+}
+
+const sleep = (ms: number) => {
+  const time = ms + SLEEP_ADD_PERCENTAGE * ms
+
+  return new Promise(resolve => setTimeout(resolve, time))
+}
 
 const Index = {
   ...CostCenters,
@@ -34,8 +128,8 @@ const Index = {
           masterdata
             .createOrUpdateSchema({
               dataEntity: schema.name,
-              schemaName: schema.version,
               schemaBody: schema.body,
+              schemaName: schema.version,
             })
             .then(() => true)
             .catch((e: any) => {
@@ -63,6 +157,97 @@ const Index = {
 
     return settings
   },
+
+  getOrganizationsWithoutSalesManager: async (
+    _: void,
+    __: void,
+    ctx: Context
+  ) => {
+    const {
+      clients: { storefrontPermissions, masterdata },
+      vtex: { adminUserAuthToken, logger },
+    } = ctx
+
+    const { checkUserPermission } = await getCheckUserPermission({
+      logger,
+      storefrontPermissions,
+    })
+
+    if (!adminUserAuthToken && !isSalesAdmin(checkUserPermission)) {
+      throw new GraphQLError('operation-not-permitted')
+    }
+
+    // getting all users
+    const users = await storefrontPermissions
+      .listAllUsers()
+      .then((result: any) => {
+        return result.data.listAllUsers
+      })
+      .catch(error => {
+        logger.error({
+          error,
+          message: 'getUsers-error',
+        })
+        if (error.message) {
+          throw new GraphQLError(error.message)
+        } else if (error.response?.data?.message) {
+          throw new GraphQLError(error.response.data.message)
+        } else {
+          throw new GraphQLError(error)
+        }
+      })
+
+    let token: string | undefined
+    let hasMore = true
+    const organizations = [] as any[]
+
+    const scrollMasterData = async () => {
+      await sleep(SCROLL_AWAIT_TIME)
+      const {
+        mdToken,
+        data,
+      }: {
+        mdToken: string
+        data: any
+      } = await masterdata.scrollDocuments({
+        dataEntity: ORGANIZATION_DATA_ENTITY,
+        fields: ORGANIZATION_FIELDS,
+        mdToken: token,
+        schema: ORGANIZATION_SCHEMA_VERSION,
+        size: SCROLL_SIZE,
+      })
+
+      if (!data.length && token) {
+        hasMore = false
+      }
+
+      if (!token && mdToken) {
+        token = mdToken
+      }
+
+      organizations.push(...data)
+      if (hasMore) {
+        await scrollMasterData()
+      }
+    }
+
+    try {
+      await scrollMasterData()
+    } catch (e) {
+      logger.error({
+        error: e,
+        message: 'scrollMasterData-error',
+      })
+      throw new GraphQLError(e)
+    }
+
+    return organizations.filter(organization => {
+      return !users
+        .filter((user: any) => user.role === 'sales-manager')
+        .find((user: any) => user.orgId === organization.id)
+    })
+  },
+
   getUsers: async (
     _: void,
     {
@@ -77,26 +262,16 @@ const Index = {
       vtex,
     } = ctx
 
-    const { sessionData } = vtex as any
+    const { organizationId: orgId } = await checkUserPermissions({
+      adminUserAuthToken,
+      logger,
+      organizationId,
+      storefrontPermissions,
+      validateUserAdmin: false,
+      vtex,
+    })
 
-    if (!adminUserAuthToken) {
-      if (!sessionData?.namespaces['storefront-permissions']) {
-        throw new GraphQLError('organization-data-not-found')
-      }
-
-      const {
-        organization: { value: userOrganizationId },
-      } = sessionData?.namespaces['storefront-permissions']
-
-      if (!organizationId) {
-        // get user's organization from session
-        organizationId = userOrganizationId
-      }
-
-      if (organizationId !== userOrganizationId) {
-        throw new GraphQLError('operation-not-permitted')
-      }
-    }
+    organizationId = orgId
 
     const variables = {
       ...(organizationId && { organizationId }),
@@ -110,8 +285,8 @@ const Index = {
       })
       .catch(error => {
         logger.error({
-          message: 'getUsers-error',
           error,
+          message: 'getUsers-error',
         })
         if (error.message) {
           throw new GraphQLError(error.message)
@@ -150,45 +325,16 @@ const Index = {
       vtex,
     } = ctx
 
-    const { sessionData } = vtex as any
+    const { organizationId: orgId } = await checkUserPermissions({
+      adminUserAuthToken,
+      logger,
+      organizationId,
+      storefrontPermissions,
+      validateUserAdmin: true,
+      vtex,
+    })
 
-    const {
-      data: { checkUserPermission },
-    }: any = await storefrontPermissions
-      .checkUserPermission('vtex.b2b-organizations@1.x')
-      .catch((error: any) => {
-        logger.error({
-          error,
-          message: 'checkUserPermission-error',
-        })
-
-        return {
-          data: {
-            checkUserPermission: null,
-          },
-        }
-      })
-
-    const isSalesAdmin = checkUserPermission?.role.slug.match(/sales-admin/)
-
-    if (!adminUserAuthToken && !isSalesAdmin) {
-      if (!sessionData?.namespaces['storefront-permissions']) {
-        throw new GraphQLError('organization-data-not-found')
-      }
-
-      const {
-        organization: { value: userOrganizationId },
-      } = sessionData?.namespaces['storefront-permissions']
-
-      if (!organizationId) {
-        // get user's organization from session
-        organizationId = userOrganizationId
-      }
-
-      if (organizationId !== userOrganizationId) {
-        throw new GraphQLError('operation-not-permitted')
-      }
-    }
+    organizationId = orgId
 
     const variables = {
       ...(organizationId && { organizationId }),
@@ -207,8 +353,8 @@ const Index = {
       })
       .catch(error => {
         logger.error({
-          message: 'getUsers-error',
           error,
+          message: 'getUsers-error',
         })
         if (error.message) {
           throw new GraphQLError(error.message)


### PR DESCRIPTION
#### What problem is this solving?

We need to get all organizations without a Sales Manager, so, it was created a new query that gets all users from the [storefront-permissions](https://github.com/vtex-apps/storefront-permissions/pull/46) and verify by getting all the organizations from MD using the scroll function.


#### How to test it?

Environment: [https://b2borg2--sandboxusdev.myvtex.com/admin/graphql-ide](https://b2borg2--sandboxusdev.myvtex.com/admin/graphql-ide)

``` graphql

query test {
  getOrganizationsWithoutSalesManager {
    id
    name
  }
}

```
