### PR TITLE
[B2BORG-115] - When trying to add the same user in two different orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added handling to the addUser mutation by showing the correct message when the user already exists.
+
 ## [0.17.0] - 2022-05-23
 
 ### Added

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -359,8 +359,12 @@ const Users = {
           error,
           message: 'addUser-error',
         })
+        const message = error.graphQLErrors[0]?.message ?? error.message
+        const status = message.includes('already exists')
+          ? 'duplicated'
+          : 'error'
 
-        return { status: 'error', message: error }
+        return { status, message }
       })
   },
 


### PR DESCRIPTION
feat: Added handling to the addUser mutation by showing the correct message when the user already exists.

#### What problem is this solving?

We were getting some problems on add the users that already exist on the store. So, this PR just handles the error message to give the user the correct feedback.

Environment: [https://b2borg--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/1574d7ea-1250-11ec-82ac-020154316047/#/users](https://b2borg--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/1574d7ea-1250-11ec-82ac-020154316047/#/users)
