### PR TITLE
[B2BORG-118] Add tradeName and phoneNumber fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for organization `tradeName` field and cost center `phoneNumber` field (both optional)
+
 ## [0.18.0] - 2022-06-03
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,28 +1,3 @@
-# [ WORK IN PROGRESS ] Admin Example
+# B2B Organizations GraphQL
 
-An example admin app that adds a menu button to the admin sidebar.
-
-# PREVIEW NOTICE :construction:
-
-We're working on the **admin builder**, which will allow you to define two files: `admin/routes.json` file with everything you need to create an admin interface (routes paths and components), and `admin/navigation.json` which alows your admin app to insert itself in the sidebar navigation. This is a temporary example!
-
-### How to develop admins
-
-1. Admins always declare routes in `/admin/app/<route>`
-
-2. Declare the `admin` builder in your manifest
-
-3. When installed, the user navigates to `/admin/<route>`, but your app runs in an iframe that points to `/admin/app/<route>`.
-
-4. You can develop directly in the `/admin/app` route for convenience, but don't forget to test it inside the iframe. :)
-
-
-### Quickstart
-
-1. Clone this repo
-
-2. `yarn --cwd react/` for code completion
-
-3. `vtex link`
-
-4. Navigate to `workspace--account.myvtex.com/admin/app/example`
+GraphQL backend for [B2B Organizations](https://github.com/vtex-apps/b2b-organizations).

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -172,6 +172,7 @@ type Pagination {
 type OrganizationRequest {
   id: ID
   name: String
+  tradeName: String
   defaultCostCenter: DefaultCostCenter
   b2bCustomerAdmin: B2BUserSimple
   status: String
@@ -188,12 +189,14 @@ type B2BUserSimple {
 type DefaultCostCenter {
   name: String
   address: Address
+  phoneNumber: String
   businessDocument: String
 }
 
 type Organization {
   id: ID
   name: String
+  tradeName: String
   collections: [Collection]
   paymentTerms: [PaymentTerm]
   priceTables: [String]
@@ -218,6 +221,7 @@ type CostCenter {
   organization: ID
   addresses: [Address]
   paymentTerms: [PaymentTerm]
+  phoneNumber: String
   businessDocument: String
 }
 
@@ -280,6 +284,7 @@ scalar Data
 
 input OrganizationInput {
   name: String
+  tradeName: String
   b2bCustomerAdmin: B2BUserInput
   defaultCostCenter: DefaultCostCenterInput
 }
@@ -293,6 +298,7 @@ input B2BUserInput {
 input DefaultCostCenterInput {
   name: String
   address: AddressInput
+  phoneNumber: String
   businessDocument: String
 }
 
@@ -300,6 +306,7 @@ input CostCenterInput {
   name: String
   addresses: [AddressInput]
   paymentTerms: [PaymentTermInput]
+  phoneNumber: String
   businessDocument: String
 }
 

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -2,18 +2,20 @@ export const ORGANIZATION_REQUEST_DATA_ENTITY = 'organization_requests'
 export const ORGANIZATION_REQUEST_FIELDS = [
   'id',
   'name',
+  'tradeName',
   'defaultCostCenter',
   'b2bCustomerAdmin',
   'status',
   'notes',
   'created',
 ]
-export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.0.4'
+export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.0.5'
 
 export const ORGANIZATION_DATA_ENTITY = 'organizations'
 export const ORGANIZATION_FIELDS = [
   'id',
   'name',
+  'tradeName',
   'collections',
   'paymentTerms',
   'priceTables',
@@ -21,7 +23,7 @@ export const ORGANIZATION_FIELDS = [
   'status',
   'created',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.6'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.7'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -30,9 +32,10 @@ export const COST_CENTER_FIELDS = [
   'addresses',
   'paymentTerms',
   'organization',
+  'phoneNumber',
   'businessDocument',
 ]
-export const COST_CENTER_SCHEMA_VERSION = 'v0.0.5'
+export const COST_CENTER_SCHEMA_VERSION = 'v0.0.6'
 
 export const schemas = [
   {
@@ -43,6 +46,10 @@ export const schemas = [
         name: {
           type: 'string',
           title: 'Name',
+        },
+        tradeName: {
+          type: ['string', 'null'],
+          title: 'Trade Name',
         },
         defaultCostCenter: {
           type: 'object',
@@ -85,6 +92,10 @@ export const schemas = [
         name: {
           type: 'string',
           title: 'Name',
+        },
+        tradeName: {
+          type: ['string', 'null'],
+          title: 'Trade Name',
         },
         collections: {
           type: 'array',
@@ -140,8 +151,12 @@ export const schemas = [
           title: 'Organization',
         },
         businessDocument: {
-          type: 'string',
+          type: ['string', 'null'],
           title: 'Business Document',
+        },
+        phoneNumber: {
+          type: ['string', 'null'],
+          title: 'Phone Number',
         },
       },
       'v-indexed': ['name', 'organization', 'businessDocument'],

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -40,6 +40,7 @@ declare module '*.json' {
 
 interface OrganizationInput {
   name: string
+  tradeName?: string
   b2bCustomerAdmin: B2BCustomerInput
   defaultCostCenter: DefaultCostCenterInput
 }
@@ -53,6 +54,7 @@ interface B2BCustomerInput {
 interface DefaultCostCenterInput {
   name: string
   address: AddressInput
+  phoneNumber?: string
   businessDocument?: string
 }
 
@@ -60,6 +62,7 @@ interface CostCenterInput {
   name: string
   addresses?: AddressInput[]
   paymentTerms?: PaymentTerm[]
+  phoneNumber?: string
   businessDocument?: string
 }
 
@@ -80,6 +83,7 @@ interface AddressInput {
 
 interface OrganizationRequest {
   name: string
+  tradeName?: string
   defaultCostCenter: DefaultCostCenterInput
   b2bCustomerAdmin: B2BCustomerInput
   status: string
@@ -89,6 +93,7 @@ interface OrganizationRequest {
 interface Organization {
   id: string
   name: string
+  tradeName?: string
   costCenters: string[]
   paymentTerms: PaymentTerm[]
   status: string
@@ -101,6 +106,7 @@ interface CostCenter {
   organization: string
   addresses: any[]
   paymentTerms: PaymentTerm[]
+  phoneNumber?: string
   businessDocument?: string
 }
 


### PR DESCRIPTION
#### What problem is this solving?

We have had a request to add `tradeName` and `phoneNumber` fields to our organization data structure, as these fields are requested in checkout. This PR lays the groundwork by updating the GraphQL schema and resolvers to accept and return these fields, as well as adding them to the Masterdata schema. 

#### How to test it?

https://b2bsuite--sandboxusdev.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.18.0/graphiql/v1

Run the following queries and mutations:

```
mutation {
  createOrganizationRequest(input: {
  	name: "(some name)"
    tradeName: "This is the Trade Name"
    b2bCustomerAdmin: {
      firstName: "(some name)"
      lastName: "(some name)"
      email: "(some unused email)"
    }
    defaultCostCenter: {
      name: "Trade Name CC"
      address: {
        addressId: "123"
        addressType: "residential"
        addressQuery: null
        postalCode: "14617"
        country: "USA"
        receiverName: "Arthur"
        city: "Rochester"
        state: "NY"
        street: "123 Fake St"
        geoCoordinates: []
      }
      phoneNumber: "5854723499"
      businessDocument: "123456"
    }
  }) {
    id
    status
  }
}
```

```
query {
  getOrganizationRequestById(id: "(id from previous step)") {
    name
    tradeName
    defaultCostCenter {
      name
      phoneNumber
      businessDocument
    }
  }
}
```

```
mutation {
  updateOrganizationRequest(id: "(id from previous step)", status: "approved") {
    id
    status
  }
}
```

```
query {
  getOrganizationById(id: "(id from mutation result)") {
    name
    tradeName
  }
  getCostCentersByOrganizationId(id: "(id from mutation result)") {
    data {
      name
      phoneNumber
      businessDocument
    }
  }
}
```