### PR TITLE
[B2BORG-118] Update schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add optional `tradeName` argument to `updateOrganization` mutation
+
 ### Added
 
 - Github Action to trigger manual tests by dispatch

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -87,6 +87,7 @@ type Mutation {
   updateOrganization(
     id: ID!
     name: String!
+    tradeName: String
     status: String!
     collections: [CollectionInput]
     paymentTerms: [PaymentTermInput]


### PR DESCRIPTION
#### What problem is this solving?

Hotfix for previous PR: https://github.com/vtex-apps/b2b-organizations-graphql/pull/48
`tradeName` argument was missing from the `updateOrganization` mutation

#### How to test it?

Linked in https://b2bsuite--sandboxusdev.myvtex.com