### PR TITLE
[B2BORG-118] Allow empty string for tradeName and phoneNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow `tradeName` and `phoneNumber` fields to be emptied when organization or cost center are updated
+
 ## [0.19.1] - 2022-06-17
 
 ### Fixed

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -3,7 +3,7 @@ import {
   COST_CENTER_SCHEMA_VERSION,
   ORGANIZATION_DATA_ENTITY,
 } from '../../mdSchema'
-import GraphQLError from '../../utils/GraphQLError'
+import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import checkConfig from '../config'
 
 const CostCenters = {
@@ -64,13 +64,7 @@ const CostCenters = {
         message: 'createCostCenter-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   createCostCenterAddress: async (
@@ -111,13 +105,7 @@ const CostCenters = {
         message: 'createCostCenterAddress-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   deleteCostCenter: async (_: void, { id }: { id: string }, ctx: Context) => {
@@ -133,13 +121,7 @@ const CostCenters = {
 
       return { status: 'success', message: '' }
     } catch (e) {
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   deleteOrganization: async (_: void, { id }: { id: string }, ctx: Context) => {
@@ -155,13 +137,7 @@ const CostCenters = {
 
       return { status: 'success', message: '' }
     } catch (e) {
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
 
@@ -202,13 +178,7 @@ const CostCenters = {
         message: 'updateCostCenter-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
 
@@ -256,13 +226,7 @@ const CostCenters = {
         message: 'updateCostCenterAddress-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
 }

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -188,9 +188,11 @@ const CostCenters = {
         fields: {
           name,
           ...(addresses?.length && { addresses }),
-          ...(paymentTerms && { paymentTerms }),
-          ...(phoneNumber && { phoneNumber }),
-          ...(businessDocument && { businessDocument }),
+          ...(paymentTerms?.length && { paymentTerms }),
+          ...((phoneNumber || phoneNumber === '') && { phoneNumber }),
+          ...((businessDocument || businessDocument === '') && {
+            businessDocument,
+          }),
         },
       })
 

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -460,7 +460,7 @@ const Organizations = {
         dataEntity: ORGANIZATION_DATA_ENTITY,
         fields: {
           name,
-          ...(tradeName && { tradeName }),
+          ...((tradeName || tradeName === '') && { tradeName }),
           status,
           collections,
           paymentTerms,

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -8,7 +8,7 @@ import {
   ORGANIZATION_REQUEST_SCHEMA_VERSION,
   ORGANIZATION_SCHEMA_VERSION,
 } from '../../mdSchema'
-import GraphQLError from '../../utils/GraphQLError'
+import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import checkConfig from '../config'
 import message from '../message'
 
@@ -82,13 +82,7 @@ const Organizations = {
         message: 'createOrganization-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   createOrganizationRequest: async (
@@ -150,13 +144,7 @@ const Organizations = {
         message: 'createOrganizationRequest-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   deleteOrganizationRequest: async (
@@ -176,13 +164,7 @@ const Organizations = {
 
       return { status: 'success', message: '' }
     } catch (e) {
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   updateOrganizationRequest: async (
@@ -216,13 +198,7 @@ const Organizations = {
         message: 'getOrganizationRequest-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
 
     // don't allow update if status is already approved or declined
@@ -309,7 +285,7 @@ const Organizations = {
             },
           })
           .then((res: any) => {
-            return res[0]?.id ?? undefined
+            return res[0]?.id
           })
           .catch(() => undefined)
 
@@ -367,13 +343,7 @@ const Organizations = {
           message: 'updateOrganizationRequest-error',
           error: e,
         })
-        if (e.message) {
-          throw new GraphQLError(e.message)
-        } else if (e.response?.data?.message) {
-          throw new GraphQLError(e.response.data.message)
-        } else {
-          throw new GraphQLError(e)
-        }
+        throw new GraphQLError(getErrorMessage(e))
       }
     }
 
@@ -395,13 +365,7 @@ const Organizations = {
 
       return { status: 'success', message: '' }
     } catch (e) {
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
   updateOrganization: async (
@@ -474,13 +438,7 @@ const Organizations = {
         message: 'updateOrganization-error',
         error: e,
       })
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
+      throw new GraphQLError(getErrorMessage(e))
     }
   },
 }

--- a/node/utils/GraphQLError.ts
+++ b/node/utils/GraphQLError.ts
@@ -6,3 +6,7 @@ export default class GraphQLError extends Error {
     this.extensions = { message, ...details }
   }
 }
+
+export const getErrorMessage = (e: any) => {
+  return e.message ?? e.response?.data?.message ?? e
+}


### PR DESCRIPTION
#### What problem is this solving?

If a user attempts to remove an organization's tradeName or a cost center's phoneNumber, the UI will report that the organization or cost center was saved successfully, but upon reloading the page, the previous value will still be present. 

This PR fixes this issue by allowing empty strings to be considered as "truthy" when updating the org or cost center. 

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com
