### PR TITLE
fix: Disable Cypress video

### DIFF
--- a/cy-runner.yml
+++ b/cy-runner.yml
@@ -35,7 +35,7 @@ base:
     maxJobs: 3
     quiet: true
     projectId: hymmzm
-    video: true
+    video: false
     videoCompression: false
     videoUploadOnPasses: false
     screenshotOnRunFailure: true


### PR DESCRIPTION
#### What problem is this solving?

Disabling Cypress video option to see if it is the case of slowness on tests.