### PR TITLE
Disable PUSH actions on GitHub

### DIFF
--- a/cy-runner.yml
+++ b/cy-runner.yml
@@ -35,7 +35,7 @@ base:
     maxJobs: 3
     quiet: true
     projectId: hymmzm
-    video: true
+    video: false
     videoCompression: false
     videoUploadOnPasses: false
     screenshotOnRunFailure: true


### PR DESCRIPTION
#### What problem is this solving?

Yesterday we saw the tests was very slow, we though the problem is video we enabled, but turns out yesterday GitHub was degraded, everything was slow. So enabling it again.