### PR TITLE
[B2BORG-123] Allow declined user send new request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow emails associated with declined requests to request new organization
+
 ## [0.19.3] - 2022-06-28
 
 ### Added

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -106,7 +106,7 @@ const Organizations = {
         fields: ORGANIZATION_REQUEST_FIELDS,
         schema: ORGANIZATION_REQUEST_SCHEMA_VERSION,
         sort: `created DESC`,
-        where: `b2bCustomerAdmin.email=${b2bCustomerAdmin.email}`,
+        where: `b2bCustomerAdmin.email=${b2bCustomerAdmin.email} AND (status=pending OR status=approved)`,
         pagination: {
           page: 1,
           pageSize: 1,


### PR DESCRIPTION
#### What problem is this solving?

The PR allows emails associated with declined requests to request new organization

#### How to test it?

[Workspace](https://aurora--b2bstoreqa.myvtex.com)
[graphiql-IDE](https://aurora--b2bstoreqa.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.19.3/graphiql/v1)

Go to the workspace to request a new organization using an email associated with a declined request, it should allow you to do so.
And go to the graphiql-IDE to test with input 
`mutation { createOrganizationRequest( input: { name: "", b2bCustomerAdmin: { firstName: "", lastName: "", email: "" } defaultCostCenter: { name: "", address: { postalCode: "", country: "", city: "", state: "", street: "", number: "", } businessDocument: "" } } ) { id href status } }`