### PR TITLE
[B2BORG-147] Fix missing addressIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- If a cost center address is missing an `addressId`, one will be automatically generated and saved when querying a cost center by ID
+
 ## [0.19.6] - 2022-08-08
 
 ### Changed

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -104,10 +104,28 @@ interface CostCenter {
   id: string
   name: string
   organization: string
-  addresses: any[]
+  addresses: Address[]
   paymentTerms: PaymentTerm[]
   phoneNumber?: string
   businessDocument?: string
+}
+
+interface Address {
+  addressId: string
+  addressType: string
+  addressQuery: string
+  postalCode: string
+  country: string
+  receiverName: string
+  city: string
+  state: string
+  street: string
+  number: string
+  complement: string
+  neighborhood: string
+  geoCoordinates: number[]
+  reference: string
+  checked?: boolean
 }
 
 interface UserArgs {


### PR DESCRIPTION
#### What problem is this solving?

A client imported many cost centers via API (not sure if it was through GraphQL or directly into MasterData) and neglected to assign `addressId`s to the cost center addresses. This caused problems with selecting addresses in checkout. To solve this problem, this PR adds logic to automatically generate and save a new `addressId` when a missing ID is detected. The app will do this whenever the `getCostCenterById` or `getCostCenterByIdStorefront` queries are used.

#### How to test it?

Go to https://hermespardini.myvtex.com/admin/graphql-ide and choose `vtex.b2b-organizations-graphql`

Use this query: 
```
query {
  getCostCenterById(id: "3072226f-b445-11ec-835d-0acb4ec87a67") {
    name
    addresses {
      addressId
      state
      postalCode
      street
    }
  }
}
```

This should return an `addressId` of `null` (if it doesn't, find a new cost center ID)

Then, run the same query here: https://arthur--hermespardini.myvtex.com/admin/graphql-ide

The `addressId` should now have a value. If you go back to master and run the original query again, the `addressId` should now be populated there as well.