### PR TITLE
bugfix binding default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the default accessibility for binding selection setting
+
 ## [0.22.1] - 2022-09-19
 
 ### Fixed

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -407,11 +407,15 @@ const Users = {
         return null
       })
 
-      if (availableSalesChannels.length) {
-        access =
-          selectedChannels?.filter((item: any) =>
-            availableSalesChannels?.includes(item)
-          ).length > 0
+      if (selectedChannels) {
+        if (availableSalesChannels.length) {
+          access =
+            selectedChannels.filter((item: any) =>
+              availableSalesChannels.includes(item)
+            ).length > 0
+        }
+      } else {
+        access = true
       }
     } catch (err) {
       logger.warn({


### PR DESCRIPTION
#### What problem is this solving?

The default of the `getBinding` should be true if no channel selected

#### How to test it?

[Setting](https://auroratest--productusqa.myvtex.com/admin/b2b-organizations/organizations#/settings)
[graphql](https://aurora142--b2bstoreqa.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.19.6/graphiql/v1?query=query%20getBinding(%24email%3A%20String!)%20%7B%0A%20%20getBinding(email%3A%20%24email)%20%0A%7D&operationName=getBinding&variables=%7B%0A%20%20%22email%22%3A%22aurora.shen%40vtex.com.br%22%0A%7D)
