### PR TITLE
Update create Organization schema and request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed createOrganization schema to accept customFields
+
 ## [0.30.3] - 2023-03-20
 
 ### Fixed

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -13,6 +13,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'paymentTerms',
   'salesChannel',
   'sellers',
+  'customFields'
 ]
 export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.1'
 
@@ -104,6 +105,10 @@ export const schemas = [
           type: ['string', 'null'],
           title: 'Sales Channel',
         },
+        customFields: {
+          type: 'array',
+          title: 'Custom Fields',
+        }
       },
       'v-indexed': ['name', 'b2bCustomerAdmin', 'status', 'created'],
       'v-immediate-indexing': true,

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -13,7 +13,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'paymentTerms',
   'salesChannel',
   'sellers',
-  'customFields'
+  'customFields',
 ]
 export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.1'
 
@@ -108,7 +108,7 @@ export const schemas = [
         customFields: {
           type: 'array',
           title: 'Custom Fields',
-        }
+        },
       },
       'v-indexed': ['name', 'b2bCustomerAdmin', 'status', 'created'],
       'v-immediate-indexing': true,

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -191,7 +191,7 @@ const Organizations = {
       b2bCustomerAdmin,
       costCenters,
       created: now,
-      customFields,
+      customFields: customFields ?? [],
       defaultCostCenter:
         defaultCostCenter ?? (costCenters?.length && costCenters[0]),
       notes: '',
@@ -426,6 +426,7 @@ const Organizations = {
             name,
             tradeName,
             sellers,
+            customFields,
           } = organizationRequest
 
           const {
@@ -461,6 +462,7 @@ const Organizations = {
                 priceTables,
                 salesChannel,
                 sellers,
+                customFields
               },
               notifyUsers,
             },

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -462,7 +462,7 @@ const Organizations = {
                 priceTables,
                 salesChannel,
                 sellers,
-                customFields
+                customFields,
               },
               notifyUsers,
             },

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -107,6 +107,7 @@ interface OrganizationRequest {
   priceTables?: Price[]
   salesChannel?: string
   sellers?: Seller[]
+  customFields?: CustomField[]
 }
 
 interface Organization {


### PR DESCRIPTION
#### What problem is this solving?
- When creating a new organization request, and the `auto approval` setting is enabled. The create Organization schema is not accepting any custom fields

#### How to test it?
- This can be tested [here](https://alberto--whitebird.myvtex.com/)