### PR TITLE
Feature/setting readonly fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added two new boolean values in order to prevent user from changing state and business field in the cost center
+
 ## [0.31.0] - 2023-03-31
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -401,7 +401,8 @@ type MarketingTags {
 
 type B2BSettings {
   autoApprove: Boolean
-  companyReadOnly: Boolean
+  businessReadOnly: Boolean
+  stateReadOnly: Boolean
   defaultPaymentTerms: [PaymentTerm]
   defaultPriceTables: [String]
   organizationCustomFields: [SettingsCustomField]
@@ -543,7 +544,8 @@ input UISettingsInput {
 
 input B2BSettingsInput {
   autoApprove: Boolean
-  companyReadOnly: Boolean
+  businessReadOnly: Boolean
+  stateReadOnly: Boolean
   defaultPaymentTerms: [PaymentTermInput]
   defaultPriceTables: [String]
   uiSettings: UISettingsInput

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -401,6 +401,7 @@ type MarketingTags {
 
 type B2BSettings {
   autoApprove: Boolean
+  companyReadOnly: Boolean
   defaultPaymentTerms: [PaymentTerm]
   defaultPriceTables: [String]
   organizationCustomFields: [SettingsCustomField]
@@ -542,6 +543,7 @@ input UISettingsInput {
 
 input B2BSettingsInput {
   autoApprove: Boolean
+  companyReadOnly: Boolean
   defaultPaymentTerms: [PaymentTermInput]
   defaultPriceTables: [String]
   uiSettings: UISettingsInput

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -32,6 +32,7 @@ const Settings = {
     {
       input: {
         autoApprove,
+        companyReadOnly,
         defaultPaymentTerms,
         defaultPriceTables,
         uiSettings,
@@ -88,6 +89,7 @@ const Settings = {
     try {
       const b2bSettings = {
         autoApprove,
+        companyReadOnly,
         costCenterCustomFields:
           costCenterCustomFields ?? currentB2BSettings?.costCenterCustomFields,
         defaultPaymentTerms,

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -32,7 +32,8 @@ const Settings = {
     {
       input: {
         autoApprove,
-        companyReadOnly,
+        businessReadOnly,
+        stateReadOnly,
         defaultPaymentTerms,
         defaultPriceTables,
         uiSettings,
@@ -89,7 +90,8 @@ const Settings = {
     try {
       const b2bSettings = {
         autoApprove,
-        companyReadOnly,
+        businessReadOnly,
+        stateReadOnly,
         costCenterCustomFields:
           costCenterCustomFields ?? currentB2BSettings?.costCenterCustomFields,
         defaultPaymentTerms,

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -154,7 +154,8 @@ interface Address {
 
 interface B2BSettings {
   autoApprove: boolean
-  companyReadOnly: boolean
+  businessReadOnly: boolean
+  stateReadOnly: boolean
   defaultPaymentTerms: PaymentTerm[]
   defaultPriceTables: [string]
   organizationCustomFields: SettingsCustomField[]
@@ -218,7 +219,8 @@ interface TransactionEmailSetting {
 
 interface B2BSettingsInput {
   autoApprove: boolean
-  companyReadOnly: boolean
+  businessReadOnly: boolean
+  stateReadOnly: boolean
   defaultPaymentTerms: PaymentTerm[]
   defaultPriceTables: Price[]
   uiSettings: UISettings

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -154,6 +154,7 @@ interface Address {
 
 interface B2BSettings {
   autoApprove: boolean
+  companyReadOnly: boolean
   defaultPaymentTerms: PaymentTerm[]
   defaultPriceTables: [string]
   organizationCustomFields: SettingsCustomField[]
@@ -217,6 +218,7 @@ interface TransactionEmailSetting {
 
 interface B2BSettingsInput {
   autoApprove: boolean
+  companyReadOnly: boolean
   defaultPaymentTerms: PaymentTerm[]
   defaultPriceTables: Price[]
   uiSettings: UISettings

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1507,7 +1507,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
- Allows user to set `state` and `document` field of the cost center read only

#### How to test it?
- This can be tested [here](https://albertob2borg--sandboxusdev.myvtex.com/)

#### Screenshots or example usage:
![Image 2023-03-31 at 5 02 43 p m](https://user-images.githubusercontent.com/11176519/229247735-245d421e-296e-41bc-99d0-7411e87e3de1.jpg)
![Image 2023-03-31 at 5 15 36 p m](https://user-images.githubusercontent.com/11176519/229248706-cd2c0533-c30c-4824-8649-e4884880554a.jpg)


