### PR TITLE
chore: configure Cabueta to report vulnerabilities

### DIFF
--- a/.github/workflows/cabueta.yml
+++ b/.github/workflows/cabueta.yml
@@ -1,0 +1,18 @@
+name: cabueta
+on:
+  workflow_dispatch:
+
+jobs:
+  cabueta:
+    uses: vtex/cabueta/.github/workflows/cabueta.yml@main
+    secrets:
+      target_url: https://www.vtexfaststore.com/
+    with:
+      dast-check: true
+      target-url: https://master--vtex.myvtex.com/_v/private/graphql/v1
+  print:
+    runs-on: ubuntu-latest
+    needs: cabueta
+    steps:
+      - name: Print output
+        run: echo ${{ needs.cabueta.outputs.report }}

--- a/.github/workflows/cabueta.yml
+++ b/.github/workflows/cabueta.yml
@@ -5,8 +5,6 @@ on:
 jobs:
   cabueta:
     uses: vtex/cabueta/.github/workflows/cabueta.yml@main
-    secrets:
-      target_url: https://www.vtexfaststore.com/
     with:
       dast-check: true
       target-url: https://master--vtex.myvtex.com/_v/private/graphql/v1

--- a/.github/workflows/cabueta.yml
+++ b/.github/workflows/cabueta.yml
@@ -7,7 +7,7 @@ jobs:
     uses: vtex/cabueta/.github/workflows/cabueta.yml@main
     with:
       dast-check: true
-      target-url: https://master--vtex.myvtex.com/_v/private/graphql/v1
+      target-url: https://b2bstoreqa.myvtex.com/_v/private/graphql/v1
   print:
     runs-on: ubuntu-latest
     needs: cabueta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+
+- Added security scan on pipeline
+
 ## [0.33.2] - 2023-06-09
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

Add [Cabueta](https://github.com/vtex/cabueta) action to scan for vulnerabilities.

The idea is call graphql operations with examples using the platform [Nuclei](https://github.com/projectdiscovery/nuclei).

#### How to test it?

After the pull request merge, it will show the workflow to execute on [Actions](https://github.com/vtex-apps/b2b-organizations-graphql/actions)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/86717da1-7e04-43e2-8301-7885acabb7ec)
