### PR TITLE
fix: adjust Cabueta source and target url

### DIFF
--- a/.github/workflows/cabueta.yml
+++ b/.github/workflows/cabueta.yml
@@ -4,10 +4,10 @@ on:
 
 jobs:
   cabueta:
-    uses: vtex/cabueta/.github/workflows/cabueta.yml@main
+    uses: gbrls/cabueta/.github/workflows/cabueta.yml@main
     with:
       dast-check: true
-      target-url: https://b2bstoreqa.myvtex.com/_v/private/graphql/v1
+      target-url: https://b2bstoreqa.myvtex.com/_v/private
   print:
     runs-on: ubuntu-latest
     needs: cabueta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+- Fix Cabueta config
+
+### Security
+
 - Added security scan on pipeline
 
 ## [0.33.3] - 2023-06-22


### PR DESCRIPTION
#### What problem is this solving?

Scan the graphql endpoint to find vulnerabilities. 

The Cabueta referenced github action was in private account, changed to use public version.
