### PR TITLE
fix: add a flag for not uploading Cabueta logs

### DIFF
--- a/.github/workflows/cabueta.yml
+++ b/.github/workflows/cabueta.yml
@@ -8,6 +8,9 @@ jobs:
     with:
       dast-check: true
       target-url: https://b2bstoreqa.myvtex.com/_v/private
+            
+      # Configure and turn this on if you want to collect logs in your endpoint
+      upload-logs: false
   print:
     runs-on: ubuntu-latest
     needs: cabueta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+- Added flag for not uploading log on Cabueta execution
+
+### Security
+
 - Fix Cabueta config
 
 ### Security


### PR DESCRIPTION
#### What problem is this solving?

It was needed to add a implicit flag for not uploading Cabueta logs. 

When the flag isn't setting, the action failed.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media4.giphy.com/media/JqJMJcEZ485CBsW1EP/giphy.gif?cid=ecf05e478undgkmmcmaozgccobojbxkigdc46g8gs6w1i3gx&ep=v1_gifs_search&rid=giphy.gif&ct=g)
