### PR TITLE
Fix: allow service routes to access session token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `/_v/private` prefix to service routes to allow session token to be forwarded to resolver
+
 ## [0.33.4] - 2023-07-19
 
 ### Fixed

--- a/node/service.json
+++ b/node/service.json
@@ -13,19 +13,19 @@
   "workers": 1,
   "routes": {
     "orders": {
-      "path": "/b2b/oms/user/orders/",
+      "path": "/_v/private/b2b/oms/user/orders/",
       "public": true
     },
     "checkout": {
-      "path": "/b2b/oms/user/checkout/",
+      "path": "/_v/private/b2b/oms/user/checkout/",
       "public": true
     },
     "order": {
-      "path": "/b2b/oms/user/orders/:orderId",
+      "path": "/_v/private/b2b/oms/user/orders/:orderId",
       "public": true
     },
     "requestCancellation": {
-      "path": "/b2b/checkout/pub/orders/:orderId/user-cancel-request",
+      "path": "/_v/private/b2b/checkout/pub/orders/:orderId/user-cancel-request",
       "public": true
     }
   }

--- a/node/service.json
+++ b/node/service.json
@@ -17,7 +17,7 @@
       "public": true
     },
     "checkout": {
-      "path": "/_v/private/b2b/oms/user/checkout/",
+      "path": "/b2b/oms/user/checkout/",
       "public": true
     },
     "order": {


### PR DESCRIPTION
#### What problem is this solving?

This app's service routes lack the `/_v/private/` prefix, meaning that the user's session token will be stripped out by our CDN when the app is accessed via the final public domain. This results in users always encountering a 403 error and unable to view their B2B order history.

This PR adds the prefix to the routes, and a matching PR will be opened on B2B Orders History so that the frontend requests the correct new paths.

I did not change the "checkout" route, as I couldn't find any app that uses it.