### PR TITLE
fix authentication when perform a GET Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix auth problem when fetching orders history
+
 ## [0.35.0] - 2023-07-24
 
 ### Added

--- a/node/clients/Oms.ts
+++ b/node/clients/Oms.ts
@@ -9,7 +9,7 @@ export default class OMSClient extends JanusClient {
       ...options,
       headers: {
         ...options?.headers,
-        VtexIdclientAutCookie: ctx.storeUserAuthToken ?? ctx.authToken,
+        VtexIdclientAutCookie: ctx.authToken,
       },
     })
   }


### PR DESCRIPTION
#### What problem is this solving?

The orders history page is not loading on the production domain of our stores. The call to /b2b/oms/users/orders fails with a 403. More details [here](https://vtex.slack.com/archives/C054PQH3GJF/p1689952463685259).

#### How to test it?

[https://shop.indola.es](https://shop.indola.es/account?workspace=ki849394#/orders-history)
[https://www.rivieraworks.ro](https://www.rivieraworks.ro/account?workspace=ki849394#/orders-history)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/xUA7aP05OSTwjR51Ic/giphy.gif)
