### PR TITLE
Fix oms route to retrieve orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix OMS route used to retrieve order info
+
 ## [0.36.0] - 2023-08-11
 
 ### Added

--- a/node/clients/Oms.ts
+++ b/node/clients/Oms.ts
@@ -32,7 +32,7 @@ export default class OMSClient extends JanusClient {
     const base = '/api/oms'
 
     return {
-      order: (id: string) => `${base}/pvt/admin/orders/${id}`,
+      order: (id: string) => `${base}/pvt/orders/${id}`,
       search: (query: string) => `${base}/pvt/orders?${query}`,
     }
   }


### PR DESCRIPTION
#### What problem is this solving?
https://vtex-dev.atlassian.net/browse/B2BTEAM-1187

On the `/orders-history` page on `My Account` (or on the order page), when clicking on the `Order Again` button, an error page would appear with the message: `Sorry, an error occurred while processing your request.`

This happens due to the oms API returning `orderGroup = null` when retrieving order info. The `orderGroup` value is used to call the checkout API and create a new cart with same items than previous order.

This PR changes the OMS API being used to a new one that actually returns the `orderGroup`. This new API returns mostly the same fields than previous API, and the fields that it does not return, are not used by the B2BSuite apps.

The only field that it returns a bit different is the `clientProfileData.email` field. Instead of returning e.g. `enzo@vtex.com.br` it returns something like: `enzo@vtex.com.br-123900000144a.ct.vtex.com.br`, so some changes regarding that were necessary on the `b2b-orders-history` app ([PR](https://github.com/vtex-apps/b2b-orders-history/pull/20))

#### How to test it?
Install fixed versions of `b2b-organizations-graphql` and `b2b-orders-history` apps, create an order and use the admin UI to complete it. After that, do the following:
* Access Orders (/orders-history) from My Account;
* Click on Order Again;
* A cart with the items from a previous order should be created (previously an error page would appear with the message "Sorry, an error occurred while processing your request.")

[Workspace](https://b2bteam1178--b2bsuite.myvtex.com/account#/orders-history)

#### Screenshots or example usage:
Page with button to click
![Captura de Tela 2023-08-30 às 15 57 15](https://github.com/vtex-apps/b2b-organizations-graphql/assets/131273915/288033e7-eec2-4f98-9d0a-57284906f6fb)

After clicking the button:
![Captura de Tela 2023-08-30 às 15 58 01](https://github.com/vtex-apps/b2b-organizations-graphql/assets/131273915/4770cf72-8afe-47fb-9078-0c964007f5ac)

Previously, after clicking the button we would see (notice the "null" on the endpoint path):
![Captura de Tela 2023-08-30 às 15 59 27](https://github.com/vtex-apps/b2b-organizations-graphql/assets/131273915/b41e6fb1-9fd4-4e9e-bd1d-8171fc28b315)

#### Related to / Depends on
https://github.com/vtex-apps/b2b-orders-history/pull/20
