### PR TITLE
Add Orders client and use it to get orders info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use Orders endpoint instead of OMS to obtain order information
+
 ## [0.36.0] - 2023-08-11
 
 ### Added

--- a/node/clients/Orders.ts
+++ b/node/clients/Orders.ts
@@ -1,0 +1,35 @@
+import type { InstanceOptions, IOContext, RequestConfig } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+import { statusToError } from '../utils'
+
+export default class OrdersClient extends JanusClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        VtexIdclientAutCookie: ctx.authToken,
+      },
+    })
+  }
+
+  public order = (id: string) =>
+    this.get(this.routes.order(id), { metric: 'orders' })
+
+  protected get = <T>(url: string, config: RequestConfig = {}) => {
+    config.headers = {
+      ...config.headers,
+    }
+
+    return this.http.get<T>(url, config).catch(statusToError)
+  }
+
+  private get routes() {
+    const base = '/api/orders'
+
+    return {
+      order: (id: string) => `${base}/pvt/document/${id}`,
+    }
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -5,6 +5,7 @@ import PaymentsClient from './payments'
 import MailClient from './email'
 import Checkout from './checkout'
 import OMSClient from './Oms'
+import OrdersClient from './Orders'
 import StorefrontPermissions from './storefrontPermissions'
 import IdentityClient from './IdentityClient'
 import Catalog from './catalog'
@@ -26,6 +27,10 @@ export class Clients extends IOClients {
 
   public get oms() {
     return this.getOrSet('oms', OMSClient)
+  }
+
+  public get orders() {
+    return this.getOrSet('orders', OrdersClient)
   }
 
   public get storefrontPermissions() {

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "0.36.0",
   "dependencies": {
-    "@vtex/api": "6.45.19",
+    "@vtex/api": "6.45.20",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -19,7 +19,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.19",
+    "@vtex/api": "6.45.20",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -831,10 +831,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.19":
-  version "6.45.19"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.19.tgz#97b449850b517d6610e7123aa91caec2a29ae7b1"
-  integrity sha512-WUsAn1Oi+Z7Ih84DcRf4HQH85Mh+zO84L0ta7zuRyb13DoAEq2qMi0Mv6vZMd9BFWOCSD8AcTHVF/gZskwh9Yw==
+"@vtex/api@6.45.20":
+  version "6.45.20"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
+  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -3470,7 +3470,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Use Orders endpoint instead of OMS endpoint to obtain order information. The new Orders endpoint returns the correct orderGroup (unlike the OMS endpoint) and this orderGroup is used to generate a new order when clicking on the "Order Again" button.

Ultimately this PR is fixing the KI: "Order Again from B2B Orders History doesn't work".

#### How to test it?

1. Make an order
2. Go to "My Account" -> "Orders"
3. Click on "Order again" button for the order you just created. It should create a new cart with the same items.

[Workspace](https://b2bteam1187--b2bstoreqa.myvtex.com/account#/orders-history)

#### Screenshots or example usage:
![8EC6DDBE-60AB-405A-9C65-5F0CC9C6C4E2](https://github.com/vtex-apps/b2b-organizations-graphql/assets/131273915/a06863eb-985c-4564-997f-4ad0a7c86719)


#### Describe alternatives you've considered, if any.
* https://github.com/vtex-apps/b2b-organizations-graphql/pull/124

