### PR TITLE
Add event trigger to deleteUser resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.36.1] - 2023-09-15
+
+### Added
+
+- Added event trigger on delete a user
+
 ## [0.36.0] - 2023-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.36.1] - 2023-09-15
-
 ### Added
 
 - Added event trigger on delete a user

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,9 @@
   },
   "policies": [
     {
+      "name": "colossus-fire-event"
+    },
+    {
       "name": "update-app-settings"
     },
     {

--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,8 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",
-    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions"
+    "vtex.b2b-organizations-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql",
+    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'",

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -412,8 +412,8 @@ const Users = {
         id,
         userId,
       })
-      .then(async (result: any) => {
-        await events.sendEvent('', 'b2b-organizations-graphql.removeUser', {
+      .then((result: any) => {
+        events.sendEvent('', 'b2b-organizations-graphql.removeUser', {
           id,
           email,
         })

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -413,7 +413,7 @@ const Users = {
         userId,
       })
       .then(async (result: any) => {
-        await new Promise(events.sendEvent('', 'b2b-organizations-graphql.removeUser', { id, email }))
+        await events.sendEvent('', 'b2b-organizations-graphql.removeUser', { id, email })
         return result.data.deleteUser
       })
       .catch((error: any) => {

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -379,7 +379,7 @@ const Users = {
     ctx: Context
   ) => {
     const {
-      clients: { storefrontPermissions: storefrontPermissionsClient },
+      clients: { events, storefrontPermissions: storefrontPermissionsClient },
       vtex: { adminUserAuthToken, logger, sessionData, storefrontPermissions },
     } = ctx as Context | any
 
@@ -412,7 +412,8 @@ const Users = {
         id,
         userId,
       })
-      .then((result: any) => {
+      .then(async (result: any) => {
+        await new Promise(events.sendEvent('', 'b2b-organizations-graphql.removeUser', { id, email }))
         return result.data.deleteUser
       })
       .catch((error: any) => {

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -413,7 +413,11 @@ const Users = {
         userId,
       })
       .then(async (result: any) => {
-        await events.sendEvent('', 'b2b-organizations-graphql.removeUser', { id, email })
+        await events.sendEvent('', 'b2b-organizations-graphql.removeUser', {
+          id,
+          email,
+        })
+
         return result.data.deleteUser
       })
       .catch((error: any) => {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3909,9 +3909,13 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions":
-  version "1.35.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions#58d27d180d75da71e43c6d6059f7191002c5f06b"
+"vtex.b2b-organizations-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql":
+  version "0.36.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql#14adc111841e871d38f888cb1c90ae4dacf1914e"
+
+"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions":
+  version "1.36.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions#9b6eca8b176bd2b4a349932a598b6b8691bd6fe9"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

Using Master Data V2, we don't have a trigger to run on "delete event" like in V1. This way we can't run scripts when deleting a user. Only on adding or updating. My motivation for this is to add the ability to run scripts after a delete action.

This modification will trigger an event sending a payload containing the is and email of the deleted user. 
With this, we can add an event listener and run scripts needed for that scenario

#### How to test it?

To test, link this branch to a workspace. Then from another app, listen to an event called `b2b-organizations-graphql.removeUser`

Like this: `service.json`
<img width="525" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/8671936/06841094-0618-4dee-9507-5dfccdda6783">


#### Screenshots or example usage:
<img width="698" alt="Screenshot 2023-09-15 at 12 00 11 PM" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/8671936/7a2f5b93-f614-419f-bbe6-562cacd6f40c">
