### PR TITLE
feat: add metric on updating organization data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add metrics on updating organization data
+
 ## [0.37.0] - 2023-09-19
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-
-- Add metrics on updating organization data
-
 ## [0.37.0] - 2023-09-19
 
 

--- a/node/package.json
+++ b/node/package.json
@@ -2,6 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "0.37.0",
   "dependencies": {
+    "@types/lodash.isequal": "^4.5.6",
     "@vtex/api": "6.45.20",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "0.37.0",
   "dependencies": {
-    "@types/lodash.isequal": "^4.5.6",
+    "@types/lodash": "4.14.74",
     "@vtex/api": "6.45.20",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
@@ -29,9 +29,8 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "5.2.2",
-    "vtex.b2b-organizations-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql",
-    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions"
+    "typescript": "3.9.7",
+    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'",

--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,7 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "3.9.7",
+    "typescript": "5.2.2",
     "vtex.b2b-organizations-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql",
     "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions"
   },

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -373,7 +373,7 @@ const Organizations = {
       ctx
     )) as B2BSettingsInput
 
-    let currentOrganizationData: Organization = {} as Organization
+    let currentOrganizationData: Organization | undefined
 
     try {
       currentOrganizationData = await masterdata.getDocument({
@@ -383,7 +383,7 @@ const Organizations = {
       })
 
       if (
-        currentOrganizationData.status !== status &&
+        currentOrganizationData?.status !== status &&
         notifyUsers &&
         settings?.transactionEmailSettings?.organizationStatusChanged
       ) {

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -419,7 +419,11 @@ const Organizations = {
         id,
       })
 
-      sendUpdateOrganizationMetric(logger, fields, currentOrganizationData)
+      sendUpdateOrganizationMetric(logger, {
+        account: ctx.vtex.account,
+        currentOrganizationData,
+        updatedProperties: fields,
+      })
 
       return { status: 'success', message: '' }
     } catch (error) {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -122,7 +122,7 @@ interface Organization {
   collections: Collection[]
   costCenters: string[]
   paymentTerms: PaymentTerm[]
-  priceTables?: Price[]
+  priceTables?: string[]
   status: string
   created: string
   customFields?: CustomField[]

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -119,11 +119,20 @@ interface Organization {
   id: string
   name: string
   tradeName?: string
+  collections: Collection[]
   costCenters: string[]
   paymentTerms: PaymentTerm[]
+  priceTables?: Price[]
   status: string
   created: string
   customFields?: CustomField[]
+  salesChannel?: string
+  sellers?: Seller[]
+}
+
+interface Collection {
+  id: string
+  name: string
 }
 
 interface CostCenter {

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -12,10 +12,19 @@ type ImpersonateB2BUserMetric = {
   description: 'Impersonate B2B User Action - Graphql'
 }
 
+interface UpdateOrganizationMetric {
+  kind: 'update-organization-graphql-event'
+  description: 'Update Organization Action - Graphql'
+}
+
 export type Metric = {
   name: 'b2b-suite-buyerorg-data'
   account: string
-} & (ImpersonateUserMetric | ImpersonateB2BUserMetric)
+} & (
+  | ImpersonateUserMetric
+  | ImpersonateB2BUserMetric
+  | UpdateOrganizationMetric
+)
 
 export const sendMetric = async (metric: Metric) => {
   try {

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -37,7 +37,7 @@ describe('given an organization to update data', () => {
       id: randAlphaNumeric().toString(),
       name: randCompanyName(),
       paymentTerms: [{ name: randAlphaNumeric() } as PaymentTerm],
-      priceTables: [{ name: randAlphaNumeric() } as Price],
+      priceTables: [randAlpha()],
       salesChannel: randAlpha(),
       sellers: [{ name: randFullName() } as Seller],
       status: randStatus(),
@@ -50,7 +50,7 @@ describe('given an organization to update data', () => {
       customFields: [{ name: randAirportName() } as CustomField],
       name: randCompanyName(),
       paymentTerms: [{ name: randLastName() } as PaymentTerm],
-      priceTables: [{ name: randFirstName() } as Price],
+      priceTables: [randFirstName()],
       salesChannel: randAirportName(),
       sellers: [{ name: randFullName() } as Seller],
       status: randStatus(),
@@ -103,7 +103,7 @@ describe('given an organization to update data', () => {
     const customFields = [{ name: randWord() } as CustomField]
     const name = randWord()
     const paymentTerms = [{ name: randWord() } as PaymentTerm]
-    const priceTables = [{ name: randWord() } as Price]
+    const priceTables = [randWord()]
     const salesChannel = randWord()
     const sellers = [{ name: randFullName() } as Seller]
     const status = randWord()

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -1,0 +1,139 @@
+import { randWord } from '@ngneat/falso'
+import type { Logger } from '@vtex/api/lib/service/logger/logger'
+
+import type { Seller } from '../../clients/sellers'
+import { sendMetric } from './metrics'
+import { sendUpdateOrganizationMetric } from './organization'
+
+jest.mock('./metrics')
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('given an organization to update data', () => {
+  describe('when change all properties data', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    const currentOrganization: Organization = {
+      collections: [{ name: randWord() } as Collection],
+      costCenters: [],
+      created: randWord(),
+      customFields: [{ name: randWord() } as CustomField],
+      id: randWord(),
+      name: randWord(),
+      paymentTerms: [{ name: randWord() } as PaymentTerm],
+      priceTables: [{ name: randWord() } as Price],
+      salesChannel: randWord(),
+      sellers: [{ name: randWord() } as Seller],
+      status: randWord(),
+      tradeName: randWord(),
+    }
+
+    const fieldsUpdated = {
+      collections: [randWord()],
+      customFields: [randWord()],
+      name: randWord(),
+      paymentTerms: [randWord()],
+      priceTables: [randWord()],
+      salesChannel: randWord(),
+      sellers: [randWord()],
+      status: randWord(),
+      tradeName: randWord(),
+    }
+
+    beforeEach(async () => {
+      await sendUpdateOrganizationMetric(
+        logger,
+        fieldsUpdated,
+        currentOrganization
+      )
+    })
+
+    it('should metric the all properties changed', () => {
+      const metricParam = {
+        description: 'Update Organization Action - Graphql',
+        fields: {
+          update_details: {
+            properties: [
+              'collections',
+              'customFields',
+              'name',
+              'paymentTerms',
+              'priceTables',
+              'salesChannel',
+              'sellers',
+              'status',
+              'tradeName',
+            ],
+          },
+        },
+        kind: 'update-organization-graphql-event',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
+
+  describe('when no change properties data', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    const collections = [{ name: randWord() } as Collection]
+    const customFields = [{ name: randWord() } as CustomField]
+    const name = randWord()
+    const paymentTerms = [{ name: randWord() } as PaymentTerm]
+    const priceTables = [{ name: randWord() } as Price]
+    const salesChannel = randWord()
+    const sellers = [{ name: randWord() } as Seller]
+    const status = randWord()
+    const tradeName = randWord()
+
+    const currentOrganization: Organization = {
+      collections,
+      costCenters: [],
+      created: randWord(),
+      customFields,
+      id: randWord(),
+      name,
+      paymentTerms,
+      priceTables,
+      salesChannel,
+      sellers,
+      status,
+      tradeName,
+    }
+
+    const fieldsUpdated = {
+      collections,
+      customFields,
+      name,
+      paymentTerms,
+      priceTables,
+      salesChannel,
+      sellers,
+      status,
+      tradeName,
+    }
+
+    beforeEach(async () => {
+      await sendUpdateOrganizationMetric(
+        logger,
+        fieldsUpdated,
+        currentOrganization
+      )
+    })
+
+    it('should metric no properties changed', () => {
+      const metricParam = {
+        description: 'Update Organization Action - Graphql',
+        fields: {
+          update_details: {
+            properties: [],
+          },
+        },
+        kind: 'update-organization-graphql-event',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
+})

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -1,4 +1,11 @@
-import { randWord } from '@ngneat/falso'
+import {
+  randAlphaNumeric,
+  randCompanyName,
+  randFullName,
+  randPastDate,
+  randStatus,
+  randWord,
+} from '@ngneat/falso'
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Seller } from '../../clients/sellers'
@@ -12,36 +19,39 @@ afterEach(() => {
 })
 
 describe('given an organization to update data', () => {
-  describe('when change all properties data', () => {
+  describe('when change all properties', () => {
     const logger = jest.fn() as unknown as Logger
 
     const account = randWord()
 
     const currentOrganization: Organization = {
-      collections: [{ name: randWord() } as Collection],
+      collections: [{ name: randAlphaNumeric() } as Collection],
       costCenters: [],
-      created: randWord(),
-      customFields: [{ name: randWord() } as CustomField],
-      id: randWord(),
-      name: randWord(),
+      created: randPastDate().toISOString(),
+      customFields: [{ name: randAlphaNumeric() } as CustomField],
+      id: randAlphaNumeric().toString(),
+      name: randCompanyName(),
       paymentTerms: [{ name: randWord() } as PaymentTerm],
       priceTables: [{ name: randWord() } as Price],
       salesChannel: randWord(),
-      sellers: [{ name: randWord() } as Seller],
-      status: randWord(),
-      tradeName: randWord(),
+      sellers: [{ name: randFullName() } as Seller],
+      status: randStatus(),
+      tradeName: randCompanyName(),
     }
 
     const fieldsUpdated: Partial<Organization> = {
-      collections: [{ name: randWord() } as Collection],
-      customFields: [{ name: randWord() } as CustomField],
-      name: randWord(),
+      collections: [{ name: randAlphaNumeric() } as Collection],
+      costCenters: [],
+      created: randPastDate().toISOString(),
+      customFields: [{ name: randAlphaNumeric() } as CustomField],
+      id: randAlphaNumeric().toString(),
+      name: randCompanyName(),
       paymentTerms: [{ name: randWord() } as PaymentTerm],
       priceTables: [{ name: randWord() } as Price],
       salesChannel: randWord(),
-      sellers: [{ name: randWord() } as Seller],
-      status: randWord(),
-      tradeName: randWord(),
+      sellers: [{ name: randFullName() } as Seller],
+      status: randStatus(),
+      tradeName: randCompanyName(),
     }
 
     const updateOrganizationParams: UpdateOrganizationParams = {
@@ -54,7 +64,7 @@ describe('given an organization to update data', () => {
       await sendUpdateOrganizationMetric(logger, updateOrganizationParams)
     })
 
-    it('should metric the all properties changed', () => {
+    it('should metrify that all properties changed', () => {
       const metricParam = {
         account,
         description: 'Update Organization Action - Graphql',
@@ -92,7 +102,7 @@ describe('given an organization to update data', () => {
     const paymentTerms = [{ name: randWord() } as PaymentTerm]
     const priceTables = [{ name: randWord() } as Price]
     const salesChannel = randWord()
-    const sellers = [{ name: randWord() } as Seller]
+    const sellers = [{ name: randFullName() } as Seller]
     const status = randWord()
     const tradeName = randWord()
 

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -136,4 +136,56 @@ describe('given an organization to update data', () => {
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
     })
   })
+  describe('when just the name, status and tradeName', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    const currentOrganization: Organization = {
+      collections: [{ id: '149', name: 'Teste 2 Jay' }],
+      costCenters: [],
+      created: '2023-05-26T17:59:51.665Z',
+      customFields: [],
+      id: '166d3921-fbef-11ed-83ab-16759f4a0add',
+      name: 'Antes',
+      paymentTerms: [],
+      priceTables: [],
+      salesChannel: '1',
+      sellers: [],
+      status: 'inactive',
+      tradeName: 'Antes',
+    }
+
+    const fieldsUpdated = {
+      collections: [{ id: '149', name: 'Teste 2 Jay' }],
+      customFields: [],
+      name: 'Depois',
+      paymentTerms: [],
+      priceTables: [],
+      salesChannel: '1',
+      sellers: [],
+      status: 'active',
+      tradeName: 'Depois',
+    }
+
+    beforeEach(async () => {
+      await sendUpdateOrganizationMetric(
+        logger,
+        fieldsUpdated,
+        currentOrganization
+      )
+    })
+
+    it('should metric just the properties changed', () => {
+      const metricParam = {
+        description: 'Update Organization Action - Graphql',
+        fields: {
+          update_details: {
+            properties: ['name', 'status', 'tradeName'],
+          },
+        },
+        kind: 'update-organization-graphql-event',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
 })

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -40,7 +40,7 @@ describe('given an organization to update data', () => {
       priceTables: [randAlpha()],
       salesChannel: randAlpha(),
       sellers: [{ name: randFullName() } as Seller],
-      status: randStatus(),
+      status: randAlpha(),
       tradeName: randCompanyName(),
     }
 

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Seller } from '../../clients/sellers'
 import { sendMetric } from './metrics'
+import type { UpdateOrganizationParams } from './organization'
 import { sendUpdateOrganizationMetric } from './organization'
 
 jest.mock('./metrics')
@@ -13,6 +14,8 @@ afterEach(() => {
 describe('given an organization to update data', () => {
   describe('when change all properties data', () => {
     const logger = jest.fn() as unknown as Logger
+
+    const account = randWord()
 
     const currentOrganization: Organization = {
       collections: [{ name: randWord() } as Collection],
@@ -41,16 +44,19 @@ describe('given an organization to update data', () => {
       tradeName: randWord(),
     }
 
+    const updateOrganizationParams: UpdateOrganizationParams = {
+      account,
+      currentOrganizationData: currentOrganization,
+      updatedProperties: fieldsUpdated,
+    }
+
     beforeEach(async () => {
-      await sendUpdateOrganizationMetric(
-        logger,
-        fieldsUpdated,
-        currentOrganization
-      )
+      await sendUpdateOrganizationMetric(logger, updateOrganizationParams)
     })
 
     it('should metric the all properties changed', () => {
       const metricParam = {
+        account,
         description: 'Update Organization Action - Graphql',
         fields: {
           update_details: {
@@ -77,6 +83,8 @@ describe('given an organization to update data', () => {
 
   describe('when no change properties data', () => {
     const logger = jest.fn() as unknown as Logger
+
+    const account = randWord()
 
     const collections = [{ name: randWord() } as Collection]
     const customFields = [{ name: randWord() } as CustomField]
@@ -115,16 +123,19 @@ describe('given an organization to update data', () => {
       tradeName,
     }
 
+    const updateOrganizationParams: UpdateOrganizationParams = {
+      account,
+      currentOrganizationData: currentOrganization,
+      updatedProperties: fieldsUpdated,
+    }
+
     beforeEach(async () => {
-      await sendUpdateOrganizationMetric(
-        logger,
-        fieldsUpdated,
-        currentOrganization
-      )
+      await sendUpdateOrganizationMetric(logger, updateOrganizationParams)
     })
 
     it('should metric no properties changed', () => {
       const metricParam = {
+        account,
         description: 'Update Organization Action - Graphql',
         fields: {
           update_details: {
@@ -140,6 +151,8 @@ describe('given an organization to update data', () => {
   })
   describe('when just the name, status and tradeName', () => {
     const logger = jest.fn() as unknown as Logger
+
+    const account = randWord()
 
     const currentOrganization: Organization = {
       collections: [{ id: '149', name: 'Teste 2 Jay' }],
@@ -168,16 +181,19 @@ describe('given an organization to update data', () => {
       tradeName: 'Depois',
     }
 
+    const updateOrganizationParams: UpdateOrganizationParams = {
+      account,
+      currentOrganizationData: currentOrganization,
+      updatedProperties: fieldsUpdated,
+    }
+
     beforeEach(async () => {
-      await sendUpdateOrganizationMetric(
-        logger,
-        fieldsUpdated,
-        currentOrganization
-      )
+      await sendUpdateOrganizationMetric(logger, updateOrganizationParams)
     })
 
     it('should metric just the properties changed', () => {
       const metricParam = {
+        account,
         description: 'Update Organization Action - Graphql',
         fields: {
           update_details: {

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -68,6 +68,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -131,6 +132,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -183,6 +185,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -42,9 +42,7 @@ describe('given an organization to update data', () => {
     const fieldsUpdated: Partial<Organization> = {
       collections: [{ name: randAlphaNumeric() } as Collection],
       costCenters: [],
-      created: randPastDate().toISOString(),
       customFields: [{ name: randAlphaNumeric() } as CustomField],
-      id: randAlphaNumeric().toString(),
       name: randCompanyName(),
       paymentTerms: [{ name: randWord() } as PaymentTerm],
       priceTables: [{ name: randWord() } as Price],

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -32,14 +32,14 @@ describe('given an organization to update data', () => {
       tradeName: randWord(),
     }
 
-    const fieldsUpdated = {
-      collections: [randWord()],
-      customFields: [randWord()],
+    const fieldsUpdated: Partial<Organization> = {
+      collections: [{ name: randWord() } as Collection],
+      customFields: [{ name: randWord() } as CustomField],
       name: randWord(),
-      paymentTerms: [randWord()],
-      priceTables: [randWord()],
+      paymentTerms: [{ name: randWord() } as PaymentTerm],
+      priceTables: [{ name: randWord() } as Price],
       salesChannel: randWord(),
-      sellers: [randWord()],
+      sellers: [{ name: randWord() } as Seller],
       status: randWord(),
       tradeName: randWord(),
     }

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -1,9 +1,14 @@
 import {
+  randAirportName,
+  randAlpha,
   randAlphaNumeric,
   randCompanyName,
+  randFirstName,
   randFullName,
+  randLastName,
   randPastDate,
   randStatus,
+  randSuperheroName,
   randWord,
 } from '@ngneat/falso'
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
@@ -25,28 +30,28 @@ describe('given an organization to update data', () => {
     const account = randWord()
 
     const currentOrganization: Organization = {
-      collections: [{ name: randAlphaNumeric() } as Collection],
+      collections: [{ name: randWord() } as Collection],
       costCenters: [],
       created: randPastDate().toISOString(),
-      customFields: [{ name: randAlphaNumeric() } as CustomField],
+      customFields: [{ name: randWord() } as CustomField],
       id: randAlphaNumeric().toString(),
       name: randCompanyName(),
-      paymentTerms: [{ name: randWord() } as PaymentTerm],
-      priceTables: [{ name: randWord() } as Price],
-      salesChannel: randWord(),
+      paymentTerms: [{ name: randAlphaNumeric() } as PaymentTerm],
+      priceTables: [{ name: randAlphaNumeric() } as Price],
+      salesChannel: randAlpha(),
       sellers: [{ name: randFullName() } as Seller],
       status: randStatus(),
       tradeName: randCompanyName(),
     }
 
     const fieldsUpdated: Partial<Organization> = {
-      collections: [{ name: randAlphaNumeric() } as Collection],
+      collections: [{ name: randSuperheroName() } as Collection],
       costCenters: [],
-      customFields: [{ name: randAlphaNumeric() } as CustomField],
+      customFields: [{ name: randAirportName() } as CustomField],
       name: randCompanyName(),
-      paymentTerms: [{ name: randWord() } as PaymentTerm],
-      priceTables: [{ name: randWord() } as Price],
-      salesChannel: randWord(),
+      paymentTerms: [{ name: randLastName() } as PaymentTerm],
+      priceTables: [{ name: randFirstName() } as Price],
+      salesChannel: randAirportName(),
       sellers: [{ name: randFullName() } as Seller],
       status: randStatus(),
       tradeName: randCompanyName(),

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -42,23 +42,31 @@ const getFieldsNamesByFieldsUpdated = (
   const { currentOrganizationData, updatedProperties } =
     updateOrganizationParams
 
-  for (const key in updatedProperties) {
-    if (Object.prototype.hasOwnProperty.call(updatedProperties, key)) {
-      const value = updatedProperties[key as keyof typeof updatedProperties]
+  if (!currentOrganizationData) {
+    return updatedPropName
+  }
 
-      // I tried to compare the objects value !== currentOrganizationData[key as keyof Organization,
-      // but it was not working, so I use JSON.stringify
-      if (
-        JSON.stringify(value) !==
-        JSON.stringify(
-          !currentOrganizationData ||
-            currentOrganizationData[key as keyof Organization]
-        )
+  Object.entries(updatedProperties).forEach(
+    ([updatedPropertyKey, updatedPropertyValue]) => {
+      if (updatedPropertyValue instanceof Array) {
+        // I tried to compare the objects value !== currentOrganizationData[key as keyof Organization,
+        // but it was not working, so I use JSON.stringify
+        if (
+          JSON.stringify(updatedPropertyValue) !==
+          JSON.stringify(
+            currentOrganizationData[updatedPropertyKey as keyof Organization]
+          )
+        ) {
+          updatedPropName.push(updatedPropertyKey)
+        }
+      } else if (
+        updatedPropertyValue !==
+        currentOrganizationData[updatedPropertyKey as keyof Organization]
       ) {
-        updatedPropName.push(key)
+        updatedPropName.push(updatedPropertyKey)
       }
     }
-  }
+  )
 
   return updatedPropName
 }

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -22,6 +22,7 @@ const buildUpdateOrganizationMetric = (
     description: 'Update Organization Action - Graphql',
     fields: updateOrganizationFields,
     kind: 'update-organization-graphql-event',
+    name: 'b2b-suite-buyerorg-data',
   } as UpdateOrganization
 }
 

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -13,8 +13,8 @@ type UpdateOrganization = Metric & {
 
 export interface UpdateOrganizationParams {
   account: string
-  currentOrganizationData: Organization
-  updatedProperties: UpdatedOrganizationProps
+  currentOrganizationData?: Organization
+  updatedProperties: Partial<Organization>
 }
 
 const buildUpdateOrganizationMetric = (
@@ -50,7 +50,10 @@ const getFieldsNamesByFieldsUpdated = (
       // but it was not working, so I use JSON.stringify
       if (
         JSON.stringify(value) !==
-        JSON.stringify(currentOrganizationData[key as keyof Organization])
+        JSON.stringify(
+          !currentOrganizationData ||
+            currentOrganizationData[key as keyof Organization]
+        )
       ) {
         updatedPropName.push(key)
       }
@@ -58,18 +61,6 @@ const getFieldsNamesByFieldsUpdated = (
   }
 
   return updatedPropName
-}
-
-export interface UpdatedOrganizationProps {
-  priceTables: any[]
-  collections: any[]
-  customFields: any[]
-  name: string
-  paymentTerms: any[]
-  salesChannel?: string
-  sellers?: any[]
-  status: string
-  tradeName?: string
 }
 
 export const sendUpdateOrganizationMetric = async (

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -35,7 +35,12 @@ const getFieldsNamesByFieldsUpdated = (
     if (Object.prototype.hasOwnProperty.call(updatedProperties, key)) {
       const value = updatedProperties[key as keyof typeof updatedProperties]
 
-      if (value !== currentOrganizationData[key as keyof Organization]) {
+      // I tried to compare the objects value !== currentOrganizationData[key as keyof Organization,
+      // but it was not working, so I use JSON.stringify
+      if (
+        JSON.stringify(value) !==
+        JSON.stringify(currentOrganizationData[key as keyof Organization])
+      ) {
         updatedPropName.push(key)
       }
     }

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -1,0 +1,79 @@
+import type { Logger } from '@vtex/api/lib/service/logger/logger'
+
+import type { Metric } from './metrics'
+import { sendMetric } from './metrics'
+
+interface UpdateOrganizationFieldsMetric {
+  update_details: { properties: string[] }
+}
+
+type UpdateOrganization = Metric & {
+  fields: UpdateOrganizationFieldsMetric
+}
+
+const buildUpdateOrganizationMetric = (
+  updatedProperties: string[]
+): UpdateOrganization => {
+  const updateOrganizationFields: UpdateOrganizationFieldsMetric = {
+    update_details: { properties: updatedProperties },
+  }
+
+  return {
+    description: 'Update Organization Action - Graphql',
+    fields: updateOrganizationFields,
+    kind: 'update-organization-graphql-event',
+  } as UpdateOrganization
+}
+
+const getFieldsNamesByFieldsUpdated = (
+  currentOrganizationData: Organization,
+  updatedProperties: UpdatedOrganizationProps
+): string[] => {
+  const updatedPropName: string[] = []
+
+  for (const key in updatedProperties) {
+    if (Object.prototype.hasOwnProperty.call(updatedProperties, key)) {
+      const value = updatedProperties[key as keyof typeof updatedProperties]
+
+      if (value !== currentOrganizationData[key as keyof Organization]) {
+        updatedPropName.push(key)
+      }
+    }
+  }
+
+  return updatedPropName
+}
+
+export interface UpdatedOrganizationProps {
+  priceTables: any[]
+  collections: any[]
+  customFields: any[]
+  name: string
+  paymentTerms: any[]
+  salesChannel?: string
+  sellers?: any[]
+  status: string
+  tradeName?: string
+}
+
+export const sendUpdateOrganizationMetric = async (
+  logger: Logger,
+  fieldsUpdated: UpdatedOrganizationProps,
+  currentOrganizationData: Organization
+) => {
+  try {
+    const fieldsNamesUpdated = getFieldsNamesByFieldsUpdated(
+      currentOrganizationData,
+      fieldsUpdated
+    )
+
+    const metric = buildUpdateOrganizationMetric(fieldsNamesUpdated)
+
+    await sendMetric(metric)
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'Error to send metrics from updateOrganization',
+    })
+  }
+}

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -11,7 +11,14 @@ type UpdateOrganization = Metric & {
   fields: UpdateOrganizationFieldsMetric
 }
 
+export interface UpdateOrganizationParams {
+  account: string
+  currentOrganizationData: Organization
+  updatedProperties: UpdatedOrganizationProps
+}
+
 const buildUpdateOrganizationMetric = (
+  account: string,
   updatedProperties: string[]
 ): UpdateOrganization => {
   const updateOrganizationFields: UpdateOrganizationFieldsMetric = {
@@ -19,6 +26,7 @@ const buildUpdateOrganizationMetric = (
   }
 
   return {
+    account,
     description: 'Update Organization Action - Graphql',
     fields: updateOrganizationFields,
     kind: 'update-organization-graphql-event',
@@ -27,10 +35,12 @@ const buildUpdateOrganizationMetric = (
 }
 
 const getFieldsNamesByFieldsUpdated = (
-  currentOrganizationData: Organization,
-  updatedProperties: UpdatedOrganizationProps
+  updateOrganizationParams: UpdateOrganizationParams
 ): string[] => {
   const updatedPropName: string[] = []
+
+  const { currentOrganizationData, updatedProperties } =
+    updateOrganizationParams
 
   for (const key in updatedProperties) {
     if (Object.prototype.hasOwnProperty.call(updatedProperties, key)) {
@@ -64,16 +74,17 @@ export interface UpdatedOrganizationProps {
 
 export const sendUpdateOrganizationMetric = async (
   logger: Logger,
-  fieldsUpdated: UpdatedOrganizationProps,
-  currentOrganizationData: Organization
+  updateOrganizationParams: UpdateOrganizationParams
 ) => {
   try {
     const fieldsNamesUpdated = getFieldsNamesByFieldsUpdated(
-      currentOrganizationData,
-      fieldsUpdated
+      updateOrganizationParams
     )
 
-    const metric = buildUpdateOrganizationMetric(fieldsNamesUpdated)
+    const metric = buildUpdateOrganizationMetric(
+      updateOrganizationParams.account,
+      fieldsNamesUpdated
+    )
 
     await sendMetric(metric)
   } catch (error) {

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -35,7 +35,7 @@ const buildUpdateOrganizationMetric = (
   } as UpdateOrganization
 }
 
-const getFieldsNamesByFieldsUpdated = (
+const getPropNamesByUpdateParams = (
   updateOrganizationParams: UpdateOrganizationParams
 ): string[] => {
   const updatedPropName: string[] = []
@@ -49,18 +49,11 @@ const getFieldsNamesByFieldsUpdated = (
 
   Object.entries(updatedProperties).forEach(
     ([updatedPropertyKey, updatedPropertyValue]) => {
-      if (updatedPropertyValue instanceof Array) {
-        if (
-          !isEqual(
-            updatedPropertyValue,
-            currentOrganizationData[updatedPropertyKey as keyof Organization]
-          )
-        ) {
-          updatedPropName.push(updatedPropertyKey)
-        }
-      } else if (
-        updatedPropertyValue !==
-        currentOrganizationData[updatedPropertyKey as keyof Organization]
+      if (
+        !isEqual(
+          updatedPropertyValue,
+          currentOrganizationData[updatedPropertyKey as keyof Organization]
+        )
       ) {
         updatedPropName.push(updatedPropertyKey)
       }
@@ -75,7 +68,7 @@ export const sendUpdateOrganizationMetric = async (
   updateOrganizationParams: UpdateOrganizationParams
 ) => {
   try {
-    const fieldsNamesUpdated = getFieldsNamesByFieldsUpdated(
+    const fieldsNamesUpdated = getPropNamesByUpdateParams(
       updateOrganizationParams
     )
 

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
+import { isEqual } from 'lodash'
 
 import type { Metric } from './metrics'
 import { sendMetric } from './metrics'
@@ -49,11 +50,9 @@ const getFieldsNamesByFieldsUpdated = (
   Object.entries(updatedProperties).forEach(
     ([updatedPropertyKey, updatedPropertyValue]) => {
       if (updatedPropertyValue instanceof Array) {
-        // I tried to compare the objects value !== currentOrganizationData[key as keyof Organization,
-        // but it was not working, so I use JSON.stringify
         if (
-          JSON.stringify(updatedPropertyValue) !==
-          JSON.stringify(
+          !isEqual(
+            updatedPropertyValue,
             currentOrganizationData[updatedPropertyKey as keyof Organization]
           )
         ) {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3846,10 +3846,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -772,6 +772,18 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/lodash.isequal@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
+  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.198"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.198.tgz#4d27465257011aedc741a809f1269941fa2c5d4c"
+  integrity sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -3470,7 +3482,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -772,17 +772,10 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
-"@types/lodash.isequal@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
-  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.198"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.198.tgz#4d27465257011aedc741a809f1269941fa2c5d4c"
-  integrity sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==
+"@types/lodash@4.14.74":
+  version "4.14.74"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+  integrity sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==
 
 "@types/mime@*":
   version "3.0.1"
@@ -3846,10 +3839,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -3921,13 +3914,9 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-"vtex.b2b-organizations-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql":
-  version "0.36.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.36.0/public/@types/vtex.b2b-organizations-graphql#14adc111841e871d38f888cb1c90ae4dacf1914e"
-
-"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions":
-  version "1.36.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.36.0/public/@types/vtex.storefront-permissions#9b6eca8b176bd2b4a349932a598b6b8691bd6fe9"
+"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions":
+  version "1.35.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.35.3/public/@types/vtex.storefront-permissions#58d27d180d75da71e43c6d6059f7191002c5f06b"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### What problem is this solving?

We need to measure the B2B Suite product better to understand the behavior of merchants and buyer organizations. As described in [this doc](https://docs.google.com/document/d/1PdtmfL4rIKpzKUBR6ZGqqixMsfFzuqI38xmtSJ8wki8/edit).

#### How to test it?

- Access some organization in the workspace, path `admin/b2b-organizations/organizations`
- Change some data
- Use the query editor on Redshift to find the event persisted 1 hour after the changes
- Query
```SQL
select 
json_extract_path_text(json_serialize(payload), 'kind') as kind,
json_extract_path_text(json_serialize(payload), 'account') as account,
payload,
ingestion_time
FROM
    vtex.schemaless.b2b_suite_buyerorg_data_raw b2b_raw
where account = 'b2bsuite'
and kind = 'update-organization-graphql-event'
```

[Workspace](https://b2bteam1260--b2bsuite.myvtex.com/admin)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/42afc06b-6c9a-46a4-85a1-c286b7a8654e)

#### Describe alternatives you've considered, if any.

I tried to consider just the fields sent from the body, but the request had all fields from the organization page, so it was necessary to compare the data between the organization persisted and the data sent in the request.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media2.giphy.com/media/cpyA1xceZkBLq/giphy.gif?cid=ecf05e47knksr4qg3srjutyw3xek3do6fjk3ytsppp7yomp7&ep=v1_gifs_search&rid=giphy.gif&ct=g)
