### PR TITLE
feat: buyer org users metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add metrics to maintain buyer organization users
+
 ## [0.38.0] - 2023-09-25
 
 ### Added

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -5,6 +5,11 @@ import {
   sendImpersonateB2BUserMetric,
   sendImpersonateUserMetric,
 } from '../../utils/metrics/impersonate'
+import {
+  sendAddUserMetric,
+  sendRemoveUserMetric,
+  sendUpdateUserMetric,
+} from '../../utils/metrics/user'
 
 export const getUserRoleSlug: (
   id: string,
@@ -406,17 +411,21 @@ const Users = {
       }
     }
 
+    const fields = {
+      email,
+      id,
+      userId,
+    }
+
     return storefrontPermissionsClient
-      .deleteUser({
-        email,
-        id,
-        userId,
-      })
+      .deleteUser(fields)
       .then((result: any) => {
         events.sendEvent('', 'b2b-organizations-graphql.removeUser', {
           id,
           email,
         })
+
+        sendRemoveUserMetric(logger, ctx.vtex.account, fields)
 
         return result.data.deleteUser
       })
@@ -460,17 +469,21 @@ const Users = {
       throw error
     }
 
+    const fields = {
+      costId,
+      email,
+      id,
+      name,
+      orgId,
+      roleId,
+      userId,
+    }
+
     return storefrontPermissionsClient
-      .addUser({
-        costId,
-        email,
-        id,
-        name,
-        orgId,
-        roleId,
-        userId,
-      })
+      .addUser(fields)
       .then((result: any) => {
+        sendAddUserMetric(logger, ctx.vtex.account, fields)
+
         return result.data.addUser
       })
       .catch((error: any) => {
@@ -538,18 +551,22 @@ const Users = {
       })
     }
 
+    const fields = {
+      clId,
+      costId,
+      email,
+      id,
+      name,
+      orgId,
+      roleId,
+      userId,
+    }
+
     return storefrontPermissionsClient
-      .updateUser({
-        clId,
-        costId,
-        email,
-        id,
-        name,
-        orgId,
-        roleId,
-        userId,
-      })
+      .updateUser(fields)
       .then((result: any) => {
+        sendUpdateUserMetric(logger, ctx.vtex.account, fields)
+
         return result.data.updateUser
       })
       .catch((error: any) => {

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -2,29 +2,12 @@ import axios from 'axios'
 
 const ANALYTICS_URL = 'https://rc.vtex.com/api/analytics/schemaless-events'
 
-type ImpersonateUserMetric = {
-  kind: 'impersonate-user-graphql-event'
-  description: 'Impersonate User Action - Graphql'
+export interface Metric {
+  readonly account: string
+  readonly kind: string
+  readonly description: string
+  readonly name: 'b2b-suite-buyerorg-data'
 }
-
-type ImpersonateB2BUserMetric = {
-  kind: 'impersonate-b2b-user-graphql-event'
-  description: 'Impersonate B2B User Action - Graphql'
-}
-
-interface UpdateOrganizationMetric {
-  kind: 'update-organization-graphql-event'
-  description: 'Update Organization Action - Graphql'
-}
-
-export type Metric = {
-  name: 'b2b-suite-buyerorg-data'
-  account: string
-} & (
-  | ImpersonateUserMetric
-  | ImpersonateB2BUserMetric
-  | UpdateOrganizationMetric
-)
 
 export const sendMetric = async (metric: Metric) => {
   try {

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -10,9 +10,5 @@ export interface Metric {
 }
 
 export const sendMetric = async (metric: Metric) => {
-  try {
-    await axios.post(ANALYTICS_URL, metric)
-  } catch (error) {
-    console.warn('Unable to log metrics', error)
-  }
+  await axios.post(ANALYTICS_URL, metric)
 }

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -17,6 +17,19 @@ export interface UpdateOrganizationParams {
   updatedProperties: Partial<Organization>
 }
 
+class UpdateOrganizationMetric implements Metric {
+  public readonly description = 'Update Organization Action - Graphql'
+  public readonly kind = 'update-organization-graphql-event'
+  public readonly account: string
+  public readonly fields: UpdateOrganizationFieldsMetric
+  public readonly name = 'b2b-suite-buyerorg-data'
+
+  constructor(account: string, fields: UpdateOrganizationFieldsMetric) {
+    this.account = account
+    this.fields = fields
+  }
+}
+
 const buildUpdateOrganizationMetric = (
   account: string,
   updatedProperties: string[]
@@ -25,13 +38,7 @@ const buildUpdateOrganizationMetric = (
     update_details: { properties: updatedProperties },
   }
 
-  return {
-    account,
-    description: 'Update Organization Action - Graphql',
-    fields: updateOrganizationFields,
-    kind: 'update-organization-graphql-event',
-    name: 'b2b-suite-buyerorg-data',
-  } as UpdateOrganization
+  return new UpdateOrganizationMetric(account, updateOrganizationFields)
 }
 
 const getFieldsNamesByFieldsUpdated = (

--- a/node/utils/metrics/user.test.ts
+++ b/node/utils/metrics/user.test.ts
@@ -1,0 +1,70 @@
+import type { Logger } from '@vtex/api/lib/service/logger/logger'
+
+import { sendMetric } from './metrics'
+
+jest.mock('./metrics')
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('given an action for an user', () => {
+  describe('when add user', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    beforeEach(async () => {
+      await sendUserMetric(logger)
+    })
+
+    it('should metrify the action', () => {
+      const metricParam = {
+        account,
+        description: 'Add User Action - Graphql',
+        fields: {},
+        kind: 'add-user-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
+
+  describe('when remove user', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    beforeEach(async () => {
+      await sendUserMetric(logger)
+    })
+
+    it('should metrify the action', () => {
+      const metricParam = {
+        account,
+        description: 'Remove User Action - Graphql',
+        fields: {},
+        kind: 'remove-user-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
+
+  describe('when update user', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    beforeEach(async () => {
+      await sendUserMetric(logger)
+    })
+
+    it('should metrify the action', () => {
+      const metricParam = {
+        account,
+        description: 'Update User Action - Graphql',
+        fields: {},
+        kind: 'update-user-graphql-event',
+        name: 'b2b-suite-buyerorg-data',
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
+})

--- a/node/utils/metrics/user.test.ts
+++ b/node/utils/metrics/user.test.ts
@@ -1,25 +1,39 @@
+import { randEmail, randWord } from '@ngneat/falso'
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import { sendMetric } from './metrics'
+import {
+  sendAddUserMetric,
+  sendRemoveUserMetric,
+  sendUpdateUserMetric,
+} from './user'
 
 jest.mock('./metrics')
 afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('given an action for an user', () => {
+describe('given an action for a user', () => {
   describe('when add user', () => {
     const logger = jest.fn() as unknown as Logger
 
+    const account = randWord()
+
+    const userArgs: Partial<UserArgs> = {
+      email: randEmail(),
+      id: randWord(),
+      userId: randWord(),
+    }
+
     beforeEach(async () => {
-      await sendUserMetric(logger)
+      await sendAddUserMetric(logger, account, userArgs)
     })
 
     it('should metrify the action', () => {
       const metricParam = {
         account,
         description: 'Add User Action - Graphql',
-        fields: {},
+        fields: userArgs,
         kind: 'add-user-graphql-event',
         name: 'b2b-suite-buyerorg-data',
       }
@@ -31,15 +45,23 @@ describe('given an action for an user', () => {
   describe('when remove user', () => {
     const logger = jest.fn() as unknown as Logger
 
+    const account = randWord()
+
+    const userArgs: Partial<UserArgs> = {
+      email: randEmail(),
+      id: randWord(),
+      userId: randWord(),
+    }
+
     beforeEach(async () => {
-      await sendUserMetric(logger)
+      await sendRemoveUserMetric(logger, account, userArgs)
     })
 
     it('should metrify the action', () => {
       const metricParam = {
         account,
         description: 'Remove User Action - Graphql',
-        fields: {},
+        fields: userArgs,
         kind: 'remove-user-graphql-event',
         name: 'b2b-suite-buyerorg-data',
       }
@@ -51,15 +73,23 @@ describe('given an action for an user', () => {
   describe('when update user', () => {
     const logger = jest.fn() as unknown as Logger
 
+    const account = randWord()
+
+    const userArgs: Partial<UserArgs> = {
+      email: randEmail(),
+      id: randWord(),
+      userId: randWord(),
+    }
+
     beforeEach(async () => {
-      await sendUserMetric(logger)
+      await sendUpdateUserMetric(logger, account, userArgs)
     })
 
     it('should metrify the action', () => {
       const metricParam = {
         account,
         description: 'Update User Action - Graphql',
-        fields: {},
+        fields: userArgs,
         kind: 'update-user-graphql-event',
         name: 'b2b-suite-buyerorg-data',
       }

--- a/node/utils/metrics/user.ts
+++ b/node/utils/metrics/user.ts
@@ -1,0 +1,87 @@
+import type { Logger } from '@vtex/api/lib/service/logger/logger'
+
+import type { Metric } from './metrics'
+import { sendMetric } from './metrics'
+
+interface UserMetricType {
+  description: string
+  kind: string
+}
+
+const userMetricType = {
+  add: {
+    description: 'Add User Action - Graphql',
+    kind: 'add-user-graphql-event',
+  } as UserMetricType,
+  remove: {
+    description: 'Remove User Action - Graphql',
+    kind: 'remove-user-graphql-event',
+  } as UserMetricType,
+  update: {
+    description: 'Update User Action - Graphql',
+    kind: 'update-user-graphql-event',
+  } as UserMetricType,
+}
+
+class UserMetric implements Metric {
+  public readonly description: string
+  public readonly kind: string
+  public readonly account: string
+  public readonly fields: Partial<UserArgs>
+  public readonly name = 'b2b-suite-buyerorg-data'
+
+  constructor(
+    account: string,
+    { kind, description }: UserMetricType,
+    fields: Partial<UserArgs>
+  ) {
+    this.account = account
+    this.fields = fields
+    this.kind = kind
+    this.description = description
+  }
+}
+
+const sendUserMetric = async (logger: Logger, userMetric: UserMetric) => {
+  try {
+    await sendMetric(userMetric)
+  } catch (error) {
+    logger.error({
+      error,
+      message: `Error to send metrics from user action ${userMetric.kind}`,
+    })
+  }
+}
+
+export const sendRemoveUserMetric = async (
+  logger: Logger,
+  account: string,
+  userArgs: Partial<UserArgs>
+) => {
+  await sendUserMetric(
+    logger,
+    new UserMetric(account, userMetricType.remove, userArgs)
+  )
+}
+
+export const sendAddUserMetric = async (
+  logger: Logger,
+  account: string,
+  userArgs: Partial<UserArgs>
+) => {
+  await sendUserMetric(
+    logger,
+    new UserMetric(account, userMetricType.add, userArgs)
+  )
+}
+
+export const sendUpdateUserMetric = async (
+  logger: Logger,
+  account: string,
+  userArgs: Partial<UserArgs>
+) => {
+  await sendUserMetric(
+    logger,
+    new UserMetric(account, userMetricType.update, userArgs)
+  )
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=vtex-apps_b2b-organizations-graphql
 sonar.organization=vtex-apps
 sonar.coverage.exclusions=**/*.test.*, */__mocks__/**.*, */node_modules/**.*, node/index.ts
+sonar.exclusions=**/*.test.*, */__mocks__/**.*, */node_modules/**.*, node/index.ts
 sonar.language=ts
 sonar.javascript.lcov.reportPaths=./node/coverage/lcov.info


### PR DESCRIPTION
#### What problem is this solving?

We need to measure the B2B Suite product better to understand the behavior of merchants and buyer organizations. As described in [this doc](https://docs.google.com/document/d/1PdtmfL4rIKpzKUBR6ZGqqixMsfFzuqI38xmtSJ8wki8/edit).

#### How to test it?

- Access some organization in the workspace, path `admin/b2b-organizations/organizations`
- Go to Users tab
- Add an user
- Update the same user
- Remove the user
- Query
```SQL
select 
json_extract_path_text(json_serialize(payload), 'kind') as kind,
json_extract_path_text(json_serialize(payload), 'account') as account,
payload,
ingestion_time
FROM
    vtex.schemaless.b2b_suite_buyerorg_data_raw b2b_raw
where kind like '%user%'
and account = 'b2bsuite'
```

[Workspace](https://b2bteam1260--b2bsuite.myvtex.com/admin)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/dc8fc365-b4c7-4992-b5eb-c2b8730a0bce)

#### Related to / Depends on

The merge for this PR depends of #127.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media3.giphy.com/media/kdsUETpGtYvS/giphy.gif?cid=ecf05e47a66t1c39gjm31u89qgr6uond1wzicr4zecidw2us&ep=v1_gifs_search&rid=giphy.gif&ct=g)
