### PR TITLE
feat: approval and rejection metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
 - Add change organization status metrics(approved or declined)
 
 ## [0.39.0] - 2023-09-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add change organization status metrics(approved or declined)
+
 ## [0.39.0] - 2023-09-25
 
 ### Added

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -18,7 +18,10 @@ import B2BSettings from '../Queries/Settings'
 import CostCenters from './CostCenters'
 import MarketingTags from './MarketingTags'
 import checkConfig from '../config'
-import { sendUpdateOrganizationMetric } from '../../utils/metrics/organization'
+import {
+  sendOrganizationStatusMetric,
+  sendUpdateOrganizationMetric,
+} from '../../utils/metrics/organization'
 
 const createUserAndAttachToOrganization = async ({
   storefrontPermissions,
@@ -620,6 +623,11 @@ const Organizations = {
             id,
           })
 
+          sendOrganizationStatusMetric(logger, {
+            account: ctx.vtex.account,
+            status: ORGANIZATION_REQUEST_STATUSES.APPROVED,
+          })
+
           return { status: 'success', message: '', id: organizationId }
         } catch (e) {
           logger.error({
@@ -654,6 +662,11 @@ const Organizations = {
           notes
         )
       }
+
+      sendOrganizationStatusMetric(logger, {
+        account: ctx.vtex.account,
+        status: ORGANIZATION_REQUEST_STATUSES.DECLINED,
+      })
 
       return { status: 'success', message: '' }
     } catch (e) {

--- a/node/utils/metrics/impersonate.ts
+++ b/node/utils/metrics/impersonate.ts
@@ -62,25 +62,21 @@ const buildMetric = (metricParams: ImpersonateMetricParams) => {
 const buildImpersonateUserMetric = (
   metricParams: ImpersonateMetricParams
 ): ImpersonateMetric => {
-  const metric: ImpersonateMetric = {
+  return {
     kind: 'impersonate-user-graphql-event',
     description: 'Impersonate User Action - Graphql',
     ...buildMetric(metricParams),
-  }
-
-  return metric
+  } as ImpersonateMetric
 }
 
 const buildImpersonateB2BUserMetric = (
   metricParams: ImpersonateMetricParams
 ): ImpersonateMetric => {
-  const metric: ImpersonateMetric = {
+  return {
     kind: 'impersonate-b2b-user-graphql-event',
     description: 'Impersonate B2B User Action - Graphql',
     ...buildMetric(metricParams),
-  }
-
-  return metric
+  } as ImpersonateMetric
 }
 
 export const sendImpersonateUserMetric = async (

--- a/node/utils/metrics/impersonate.ts
+++ b/node/utils/metrics/impersonate.ts
@@ -1,5 +1,5 @@
 import type { Metric } from './metrics'
-import { sendMetric } from './metrics'
+import { B2B_METRIC_NAME, sendMetric } from './metrics'
 
 type ImpersonatePerson = {
   email: string
@@ -42,7 +42,7 @@ const buildMetric = (metricParams: ImpersonateMetricParams) => {
     : undefined
 
   const metric = {
-    name: 'b2b-suite-buyerorg-data' as const,
+    name: B2B_METRIC_NAME,
     account,
     fields: {
       user: userParam,

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -2,11 +2,13 @@ import axios from 'axios'
 
 const ANALYTICS_URL = 'https://rc.vtex.com/api/analytics/schemaless-events'
 
+export const B2B_METRIC_NAME = 'b2b-suite-buyerorg-data'
+
 export interface Metric {
   readonly account: string
   readonly kind: string
   readonly description: string
-  readonly name: 'b2b-suite-buyerorg-data'
+  readonly name: typeof B2B_METRIC_NAME
 }
 
 export const sendMetric = async (metric: Metric) => {

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -14,9 +14,16 @@ import {
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Seller } from '../../clients/sellers'
-import { sendMetric } from './metrics'
-import type { UpdateOrganizationParams } from './organization'
-import { sendUpdateOrganizationMetric } from './organization'
+import { ORGANIZATION_REQUEST_STATUSES } from '../constants'
+import { B2B_METRIC_NAME, sendMetric } from './metrics'
+import type {
+  OrganizationStatusParams,
+  UpdateOrganizationParams,
+} from './organization'
+import {
+  sendOrganizationStatusMetric,
+  sendUpdateOrganizationMetric,
+} from './organization'
 
 jest.mock('./metrics')
 afterEach(() => {
@@ -87,7 +94,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -156,7 +163,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -214,7 +221,7 @@ describe('given an organization to update data', () => {
           },
         },
         kind: 'update-organization-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -227,4 +227,33 @@ describe('given an organization to update data', () => {
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
     })
   })
+
+  describe('when need to update status', () => {
+    const logger = jest.fn() as unknown as Logger
+
+    const account = randWord()
+
+    const updateOrganizationParams: OrganizationStatusParams = {
+      account,
+      status: ORGANIZATION_REQUEST_STATUSES.APPROVED,
+    }
+
+    beforeEach(async () => {
+      await sendOrganizationStatusMetric(logger, updateOrganizationParams)
+    })
+
+    it('should metrify the status changed', () => {
+      const metricParam = {
+        account,
+        description: 'Change Organization Status Action - Graphql',
+        fields: {
+          status: ORGANIZATION_REQUEST_STATUSES.APPROVED,
+        },
+        kind: 'change-organization-status-graphql-event',
+        name: B2B_METRIC_NAME,
+      }
+
+      expect(sendMetric).toHaveBeenCalledWith(metricParam)
+    })
+  })
 })

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@vtex/api/lib/service/logger/logger'
 import { isEqual } from 'lodash'
 
 import type { Metric } from './metrics'
-import { sendMetric } from './metrics'
+import { B2B_METRIC_NAME, sendMetric } from './metrics'
 
 interface UpdateOrganizationFieldsMetric {
   update_details: { properties: string[] }
@@ -23,7 +23,7 @@ class UpdateOrganizationMetric implements Metric {
   public readonly kind = 'update-organization-graphql-event'
   public readonly account: string
   public readonly fields: UpdateOrganizationFieldsMetric
-  public readonly name = 'b2b-suite-buyerorg-data'
+  public readonly name = B2B_METRIC_NAME
 
   constructor(account: string, fields: UpdateOrganizationFieldsMetric) {
     this.account = account

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -18,6 +18,11 @@ export interface UpdateOrganizationParams {
   updatedProperties: Partial<Organization>
 }
 
+export interface OrganizationStatusParams {
+  account: string
+  status: string
+}
+
 class UpdateOrganizationMetric implements Metric {
   public readonly description = 'Update Organization Action - Graphql'
   public readonly kind = 'update-organization-graphql-event'
@@ -89,6 +94,28 @@ export const sendUpdateOrganizationMetric = async (
     logger.error({
       error,
       message: 'Error to send metrics from updateOrganization',
+    })
+  }
+}
+
+export const sendOrganizationStatusMetric = async (
+  logger: Logger,
+  statusParams: OrganizationStatusParams
+) => {
+  try {
+    await sendMetric({
+      account: statusParams.account,
+      description: 'Change Organization Status Action - Graphql',
+      fields: {
+        status: statusParams.status,
+      },
+      kind: 'change-organization-status-graphql-event',
+      name: B2B_METRIC_NAME,
+    } as unknown as Metric)
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'Error to send metrics from organization status change',
     })
   }
 }

--- a/node/utils/metrics/user.test.ts
+++ b/node/utils/metrics/user.test.ts
@@ -1,7 +1,7 @@
 import { randEmail, randWord } from '@ngneat/falso'
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
-import { sendMetric } from './metrics'
+import { B2B_METRIC_NAME, sendMetric } from './metrics'
 import {
   sendAddUserMetric,
   sendRemoveUserMetric,
@@ -35,7 +35,7 @@ describe('given an action for a user', () => {
         description: 'Add User Action - Graphql',
         fields: userArgs,
         kind: 'add-user-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -63,7 +63,7 @@ describe('given an action for a user', () => {
         description: 'Remove User Action - Graphql',
         fields: userArgs,
         kind: 'remove-user-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)
@@ -91,7 +91,7 @@ describe('given an action for a user', () => {
         description: 'Update User Action - Graphql',
         fields: userArgs,
         kind: 'update-user-graphql-event',
-        name: 'b2b-suite-buyerorg-data',
+        name: B2B_METRIC_NAME,
       }
 
       expect(sendMetric).toHaveBeenCalledWith(metricParam)

--- a/node/utils/metrics/user.ts
+++ b/node/utils/metrics/user.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Metric } from './metrics'
-import { sendMetric } from './metrics'
+import { B2B_METRIC_NAME, sendMetric } from './metrics'
 
 interface UserMetricType {
   description: string
@@ -28,7 +28,7 @@ class UserMetric implements Metric {
   public readonly kind: string
   public readonly account: string
   public readonly fields: Partial<UserArgs>
-  public readonly name = 'b2b-suite-buyerorg-data'
+  public readonly name = B2B_METRIC_NAME
 
   constructor(
     account: string,


### PR DESCRIPTION
#### What problem is this solving?

We need to measure the B2B Suite product better to understand the behavior of merchants and buyer organizations. As described in [this doc](https://docs.google.com/document/d/1PdtmfL4rIKpzKUBR6ZGqqixMsfFzuqI38xmtSJ8wki8/edit).

#### How to test it?

- Access some organization request in the workspace, path `/admin/b2b-organizations/requests`
- Visualize an organization with status "Pending"
- Click in the button "Approve" or "Reject"
```SQL
select 
json_extract_path_text(json_serialize(payload), 'kind') as kind,
json_extract_path_text(json_serialize(payload), 'account') as account,
payload,
ingestion_time
FROM
    vtex.schemaless.b2b_suite_buyerorg_data_raw b2b_raw
where kind  = 'change-organization-status-graphql-event'
and account = 'b2bsuite'
```

[Workspace](https://b2bteam1254--b2bsuite.myvtex.com/admin)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/de52d19e-88ea-4072-a69a-796f63127b54)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media1.giphy.com/media/ytwDCudyHqiftjn2mc/giphy.gif?cid=ecf05e47o4pn9g9e247osqzlfm7kg9sqiaqcl8vzsev2t9ld&ep=v1_gifs_search&rid=giphy.gif&ct=g)
