### PR TITLE
fix: impersonate user with sales role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix to impersonate user with the role `sales`
+
 ## [0.40.0] - 2023-09-29
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
   "version": "0.40.0",
   "dependencies": {
     "@types/lodash": "4.14.74",
-    "@vtex/api": "6.45.20",
+    "@vtex/api": "6.45.22",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.20",
+    "@vtex/api": "6.45.22",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/resolvers/Mutations/Users.test.ts
+++ b/node/resolvers/Mutations/Users.test.ts
@@ -1,0 +1,290 @@
+import { randAlphaNumeric, randEmail, randUser, randUuid } from '@ngneat/falso'
+import { GraphQLError } from 'graphql'
+
+import Users from './Users'
+
+jest.mock('../config')
+jest.mock('../../utils/metrics/impersonate')
+
+const mockContext = (
+  impersonateUser = randUser(),
+  permissions: string[] = [],
+  costId: string = randUuid(),
+  orgId: string = randUuid()
+) => {
+  return {
+    clients: {
+      storefrontPermissions: {
+        getB2BUser: jest.fn().mockResolvedValue({
+          data: {
+            getB2BUser: {
+              costId,
+              orgId,
+            },
+          },
+        }),
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            getUser: {
+              costId,
+              orgId,
+            },
+          },
+        }),
+        impersonateUser: jest.fn().mockResolvedValue({
+          data: {
+            impersonateUser,
+          },
+        }),
+      },
+    },
+    vtex: {
+      logger: jest.fn(),
+      sessionData: {
+        namespaces: {
+          'storefront-permissions': {
+            costcenter: {
+              value: costId,
+            },
+            organization: {
+              value: orgId,
+            },
+            storeUserEmail: randEmail(),
+            userId: randUuid(),
+            userTargetId: randUuid(),
+          },
+        },
+      },
+      storefrontPermissions: {
+        permissions,
+      },
+    },
+  } as unknown as Context
+}
+
+describe('given an Users Mutation', () => {
+  describe('when impersonate an B2B user', () => {
+    describe('with invalid permission', () => {
+      const user = randUser()
+
+      const mockedContext = mockContext()
+
+      it('should throws GraphQLError with operation-not-permitted.', async () => {
+        await expect(
+          Users.impersonateB2BUser(jest.fn() as never, user, mockedContext)
+        ).rejects.toThrowError(new GraphQLError('operation-not-permitted'))
+      })
+    })
+
+    describe('with permission impersonate-users-costcenter and the user with same costcenter', () => {
+      const user = randUser()
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-costcenter',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateB2BUser(
+          jest.fn() as never,
+          user,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId: user.id })
+      })
+
+      it('should return impersonate user data', () => {
+        expect(result).toEqual(impersonateUser)
+      })
+    })
+
+    describe('with permission impersonate-users-organization and the user with same organization', () => {
+      const user = randUser()
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-organization',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateB2BUser(
+          jest.fn() as never,
+          user,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId: user.id })
+      })
+
+      it('should return impersonate user data', () => {
+        expect(result).toEqual(impersonateUser)
+      })
+    })
+
+    describe('with permission impersonate-users-all', () => {
+      const user = randUser()
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-all',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateB2BUser(
+          jest.fn() as never,
+          user,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId: user.id })
+      })
+
+      it('should return impersonate user data', () => {
+        expect(result).toEqual(impersonateUser)
+      })
+    })
+  })
+
+  describe('when impersonate an user', () => {
+    describe('with invalid permission', () => {
+      const clId = randAlphaNumeric({ length: 10 }).toString()
+      const userId = randUser().id
+      const user: Partial<UserArgs> = { clId, userId }
+      const mockedContext = mockContext()
+
+      it('should throws GraphQLError with operation-not-permitted.', async () => {
+        await expect(
+          Users.impersonateUser(
+            jest.fn() as never,
+            user as UserArgs,
+            mockedContext
+          )
+        ).rejects.toThrowError(new GraphQLError('operation-not-permitted'))
+      })
+    })
+
+    describe('with permission impersonate-users-costcenter and the user with same costcenter', () => {
+      const clId = randAlphaNumeric({ length: 10 }).toString()
+      const userId = randUser().id
+      const user: Partial<UserArgs> = { clId, userId }
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-costcenter',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateUser(
+          jest.fn() as never,
+          user as UserArgs,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId })
+      })
+
+      it('should not return error', () => {
+        expect(result?.status).not.toEqual('error')
+      })
+    })
+
+    describe('with permission impersonate-users-organization and the user with same organization', () => {
+      const clId = randAlphaNumeric({ length: 10 }).toString()
+      const userId = randUser().id
+      const user: Partial<UserArgs> = { clId, userId }
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-organization',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateUser(
+          jest.fn() as never,
+          user as UserArgs,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId })
+      })
+
+      it('should not return error', () => {
+        expect(result?.status).not.toEqual('error')
+      })
+    })
+
+    describe('with permission impersonate-users-all', () => {
+      const clId = randAlphaNumeric({ length: 10 }).toString()
+      const userId = randUser().id
+      const user: Partial<UserArgs> = { clId, userId }
+      const impersonateUser = randUser()
+
+      const mockedContext = mockContext(impersonateUser, [
+        'impersonate-users-all',
+      ])
+
+      let result: any
+
+      beforeEach(async () => {
+        result = await Users.impersonateUser(
+          jest.fn() as never,
+          user as UserArgs,
+          mockedContext
+        )
+      })
+      it('should call impersonate user in storefront permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          mockedContext.clients.storefrontPermissions.impersonateUser
+        ).toBeCalledWith({ userId })
+      })
+
+      it('should not return error', () => {
+        expect(result?.status).not.toEqual('error')
+      })
+    })
+  })
+})

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -48,7 +48,7 @@ const isUserPermitted = ({
   roleSlug,
 }: any) =>
   (storefrontPermissions?.permissions?.includes('add-users-organization') &&
-    sessionData.namespaces['storefront-permissions'].organization.value ===
+    sessionData.namespaces['storefront-permissions']?.organization?.value ===
       orgId &&
     !roleSlug.includes('sales')) ||
   (storefrontPermissions?.permissions?.includes('add-sales-users-all') &&
@@ -183,26 +183,27 @@ const Users = {
       const result = await storefrontPermissionsClient.getRole(user.roleId)
       const roleSlug = result?.data?.getRole?.slug
 
-      let permitted = false
+      const hasImpersonateUsersCostCenterPermission =
+        !roleSlug.includes('admin') &&
+        storefrontPermissions?.permissions?.includes(
+          'impersonate-users-costcenter'
+        ) &&
+        user?.costId ===
+          sessionData?.namespaces['storefront-permissions']?.costcenter?.value
 
-      if (!roleSlug.includes('sales')) {
-        permitted =
-          (storefrontPermissions?.permissions?.includes(
-            'impersonate-users-costcenter'
-          ) &&
-            !roleSlug.includes('admin') &&
-            user?.costId ===
-              sessionData?.namespaces['storefront-permissions']?.costcenter) ||
-          (storefrontPermissions?.permissions?.includes(
-            'impersonate-users-organization'
-          ) &&
-            user?.orgId ===
-              sessionData?.namespaces['storefront-permissions']
-                ?.organization) ||
-          storefrontPermissions?.permissions?.includes('impersonate-users-all')
-      }
+      const hasImpersonateUsersOrganizationPermission =
+        storefrontPermissions?.permissions?.includes(
+          'impersonate-users-organization'
+        ) &&
+        user?.orgId ===
+          sessionData?.namespaces['storefront-permissions']?.organization?.value
 
-      if (!permitted) {
+      if (
+        !(
+          hasImpersonateUsersCostCenterPermission ||
+          hasImpersonateUsersOrganizationPermission
+        )
+      ) {
         throw new GraphQLError('operation-not-permitted')
       }
     }
@@ -300,13 +301,14 @@ const Users = {
           ) &&
             !roleSlug.includes('admin') &&
             userInfo?.costId ===
-              sessionData?.namespaces['storefront-permissions']?.costcenter) ||
+              sessionData?.namespaces['storefront-permissions']?.costcenter
+                ?.value) ||
           (storefrontPermissions?.permissions?.includes(
             'impersonate-users-organization'
           ) &&
             userInfo?.orgId ===
-              sessionData?.namespaces['storefront-permissions']
-                ?.organization) ||
+              sessionData?.namespaces['storefront-permissions']?.organization
+                ?.value) ||
           storefrontPermissions?.permissions?.includes('impersonate-users-all')
       }
 

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -180,11 +180,7 @@ const Users = {
         throw new GraphQLError('organization-data-not-found')
       }
 
-      const result = await storefrontPermissionsClient.getRole(user.roleId)
-      const roleSlug = result?.data?.getRole?.slug
-
       const canImpersonateUsersWithCostCenterPermission =
-        !roleSlug.includes('admin') &&
         storefrontPermissions?.permissions?.includes(
           'impersonate-users-costcenter'
         ) &&

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -183,7 +183,7 @@ const Users = {
       const result = await storefrontPermissionsClient.getRole(user.roleId)
       const roleSlug = result?.data?.getRole?.slug
 
-      const hasImpersonateUsersCostCenterPermission =
+      const canImpersonateUsersWithCostCenterPermission =
         !roleSlug.includes('admin') &&
         storefrontPermissions?.permissions?.includes(
           'impersonate-users-costcenter'
@@ -191,16 +191,20 @@ const Users = {
         user?.costId ===
           sessionData?.namespaces['storefront-permissions']?.costcenter?.value
 
-      const hasImpersonateUsersOrganizationPermission =
+      const canImpersonateUsersWithOrganizationPermission =
         storefrontPermissions?.permissions?.includes(
           'impersonate-users-organization'
         ) &&
         user?.orgId ===
           sessionData?.namespaces['storefront-permissions']?.organization?.value
 
+      const canImpersonateUsersWithAllPermission =
+        storefrontPermissions?.permissions?.includes('impersonate-users-all')
+
       if (
-        !hasImpersonateUsersCostCenterPermission &&
-        !hasImpersonateUsersOrganizationPermission
+        !canImpersonateUsersWithCostCenterPermission &&
+        !canImpersonateUsersWithOrganizationPermission &&
+        !canImpersonateUsersWithAllPermission
       ) {
         throw new GraphQLError('operation-not-permitted')
       }

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -199,10 +199,8 @@ const Users = {
           sessionData?.namespaces['storefront-permissions']?.organization?.value
 
       if (
-        !(
-          hasImpersonateUsersCostCenterPermission ||
-          hasImpersonateUsersOrganizationPermission
-        )
+        !hasImpersonateUsersCostCenterPermission &&
+        !hasImpersonateUsersOrganizationPermission
       ) {
         throw new GraphQLError('operation-not-permitted')
       }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -836,10 +836,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.20":
-  version "6.45.20"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
-  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
+"@vtex/api@6.45.22":
+  version "6.45.22"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
+  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -3475,7 +3475,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The users with the `sales` roles can't impersonate users, even if they have permission.

#### How to test it?

- Open the path /account#/organization, log with sales role account
- Go to Users
- Click in the 3 points to impersonate the user.

[Workspace](https://www.rivieraworks.ro/account?workspace=ki910328#/organization)

#### Screenshots or example usage:

![Screen Recording 2023-10-05 at 17 27 10](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/e01a1d74-9608-4004-bbe6-b54d3c896e6a)
