### PR TITLE
feat: add to create an organization and cost center with a specified ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- add new mutation to create organization and cost center specifying the id
+
 ## [0.41.0] - 2023-10-09
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -107,6 +107,9 @@ type Mutation {
   ): OrganizationCostCenterResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)
+  createOrganizationAndCostCenterWithAdminUser(
+    input: OrganizationInput!
+  ): MasterDataResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
   createCostCenter(
     organizationId: ID
     input: CostCenterInput!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -440,6 +440,7 @@ type UISettings {
 scalar Data
 
 input OrganizationInput {
+  id: String
   name: String
   tradeName: String
   b2bCustomerAdmin: B2BUserInput
@@ -459,6 +460,7 @@ input B2BUserInput {
 }
 
 input DefaultCostCenterInput {
+  id: String
   name: String
   address: AddressInput
   phoneNumber: String

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -107,7 +107,7 @@ type Mutation {
   ): OrganizationCostCenterResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)
-  createOrganizationAndCostCenterWithAdminUser(
+  createOrganizationAndCostCentersWithId(
     input: OrganizationInput!
   ): MasterDataResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
   createCostCenter(

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -64,7 +64,7 @@ const CostCenters = {
         stateRegistration,
       }
 
-      return await CostCenterRepository.saveCostCenter(
+      return await CostCenterRepository.createCostCenter(
         _,
         organizationId,
         costCenter,

--- a/node/resolvers/Mutations/Organizations.test.ts
+++ b/node/resolvers/Mutations/Organizations.test.ts
@@ -1,4 +1,5 @@
 import {
+  randAddress,
   randAirportName,
   randCompanyName,
   randEmail,
@@ -16,7 +17,11 @@ import {
   ORGANIZATION_DATA_ENTITY,
   ORGANIZATION_SCHEMA_VERSION,
 } from '../../mdSchema'
-import type { OrganizationInput, OrganizationRequest } from '../../typings'
+import type {
+  AddressInput,
+  OrganizationInput,
+  OrganizationRequest,
+} from '../../typings'
 import { ORGANIZATION_REQUEST_STATUSES } from '../../utils/constants'
 import Organizations from './Organizations'
 
@@ -93,6 +98,7 @@ describe('given an Organization Mutation', () => {
           lastName: randLastName(),
         },
         defaultCostCenter: {
+          address: randAddress(),
           stateRegistration,
         },
         id: orgId,
@@ -124,7 +130,7 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(2, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [organization.defaultCostCenter?.address],
             organization: orgId,
             stateRegistration,
           },
@@ -175,7 +181,7 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(2, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [],
             organization: orgId,
           },
           schema: COST_CENTER_SCHEMA_VERSION,
@@ -194,10 +200,12 @@ describe('given an Organization Mutation', () => {
 
     describe('with organization id and without cost center id', () => {
       const costCenter = {
+        address: randAddress() as unknown as AddressInput,
         name: randLastName(),
       }
 
       const defaultCostCenter = {
+        address: randAddress() as unknown as AddressInput,
         name: randSuperheroName(),
       }
 
@@ -253,9 +261,10 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(2, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [costCenter.address],
+            id: undefined,
+            name: costCenter.name,
             organization: orgId,
-            ...costCenter,
           },
           schema: COST_CENTER_SCHEMA_VERSION,
         })
@@ -266,9 +275,9 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(3, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [defaultCostCenter.address],
+            name: defaultCostCenter.name,
             organization: orgId,
-            ...defaultCostCenter,
           },
           schema: COST_CENTER_SCHEMA_VERSION,
         })
@@ -352,7 +361,7 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(2, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [],
             organization: orgId,
             ...costCenter,
           },
@@ -365,7 +374,7 @@ describe('given an Organization Mutation', () => {
         ).toHaveBeenNthCalledWith(3, {
           dataEntity: COST_CENTER_DATA_ENTITY,
           fields: {
-            addresses: undefined,
+            addresses: [],
             organization: orgId,
             ...defaultCostCenter,
           },

--- a/node/resolvers/Mutations/Organizations.test.ts
+++ b/node/resolvers/Mutations/Organizations.test.ts
@@ -221,7 +221,7 @@ describe('given an Organization Mutation', () => {
         tradeName: randAirportName(),
       } as OrganizationInput
 
-      let result: { href: any; organizationId: any }
+      let result: { href: any; id: any }
       let mockedContext: Context
 
       const roleId = randUuid()
@@ -295,7 +295,7 @@ describe('given an Organization Mutation', () => {
         })
       })
       it('should create the organization with the id specified', () => {
-        expect(result.organizationId).toEqual(orgId)
+        expect(result.id).toEqual(orgId)
       })
     })
     describe('with organization id and cost center id', () => {
@@ -321,7 +321,7 @@ describe('given an Organization Mutation', () => {
         tradeName: randAirportName(),
       } as OrganizationInput
 
-      let result: { href: any; organizationId: any }
+      let result: { href: any; id: any }
       let mockedContext: Context
 
       const createDate = new Date('2020-01-01')
@@ -404,7 +404,7 @@ describe('given an Organization Mutation', () => {
         })
       })
       it('should create the organization with the id specified', () => {
-        expect(result.organizationId).toEqual(orgId)
+        expect(result.id).toEqual(orgId)
       })
     })
   })

--- a/node/resolvers/Mutations/Organizations.test.ts
+++ b/node/resolvers/Mutations/Organizations.test.ts
@@ -1,11 +1,22 @@
 import {
+  randAirportName,
+  randCompanyName,
   randEmail,
   randFirstName,
   randLastName,
+  randSuperheroName,
+  randUser,
   randUuid,
   randWord,
 } from '@ngneat/falso'
 
+import {
+  COST_CENTER_DATA_ENTITY,
+  COST_CENTER_SCHEMA_VERSION,
+  ORGANIZATION_DATA_ENTITY,
+  ORGANIZATION_SCHEMA_VERSION,
+} from '../../mdSchema'
+import type { OrganizationInput, OrganizationRequest } from '../../typings'
 import { ORGANIZATION_REQUEST_STATUSES } from '../../utils/constants'
 import Organizations from './Organizations'
 
@@ -14,12 +25,16 @@ jest.mock('../Queries/Settings')
 
 const mockedOrganizations = Organizations as jest.Mocked<typeof Organizations>
 
-const mockContext = (stateRegistration?: string) => {
+const mockContext = (
+  createdId: string = randUuid(),
+  roleId: string = randUuid(),
+  stateRegistration?: string
+) => {
   return {
     clients: {
       masterdata: {
         createDocument: jest.fn().mockResolvedValue({
-          DocumentId: randUuid(),
+          DocumentId: createdId,
         }),
         getDocument: jest.fn().mockResolvedValueOnce({
           b2bCustomerAdmin: {
@@ -37,10 +52,12 @@ const mockContext = (stateRegistration?: string) => {
         updatePartialDocument: jest.fn().mockResolvedValueOnce({}),
       },
       storefrontPermissions: {
-        listRoles: jest.fn().mockResolvedValueOnce({
-          data: { listRoles: [{ id: randUuid(), slug: 'customer-admin' }] },
+        listRoles: jest.fn().mockResolvedValue({
+          data: { listRoles: [{ id: roleId, slug: 'customer-admin' }] },
         }),
-        saveUser: jest.fn().mockResolvedValueOnce({ data: {} }),
+        saveUser: jest
+          .fn()
+          .mockResolvedValue({ data: { saveUser: randUser() } }),
       },
     },
     vtex: {
@@ -54,89 +71,303 @@ afterEach(() => {
 })
 
 describe('given an Organization Mutation', () => {
-  const orgId = randUuid()
-  const input = {
-    id: '1',
-    notes: 'OK',
-    notifyUsers: true,
-    status: ORGANIZATION_REQUEST_STATUSES.APPROVED,
-  }
+  describe('when update an organization', () => {
+    const orgId = randUuid()
+    const input = {
+      id: '1',
+      notes: 'OK',
+      notifyUsers: true,
+      status: ORGANIZATION_REQUEST_STATUSES.APPROVED,
+    }
 
-  let result: { id?: string; message: string; status: string }
-  let mockedContext: Context
+    let result: { id?: string; message: string; status: string }
+    let mockedContext: Context
 
-  beforeEach(() => {
-    jest
-      .spyOn(mockedOrganizations, 'createOrganization')
-      .mockResolvedValueOnce({
-        costCenterId: randUuid(),
-        href: '',
-        id: orgId,
-        status: '',
+    beforeEach(() => {
+      jest
+        .spyOn(mockedOrganizations, 'createOrganization')
+        .mockResolvedValueOnce({
+          costCenterId: randUuid(),
+          href: '',
+          id: orgId,
+          status: '',
+        })
+    })
+
+    describe('with status APPROVED and state registration', () => {
+      const stateRegistration = randWord()
+
+      beforeEach(async () => {
+        mockedContext = mockContext(stateRegistration)
+        result = await Organizations.updateOrganizationRequest(
+          jest.fn() as never,
+          input,
+          mockedContext
+        )
       })
+
+      it('should return organization id with success', () => {
+        expect(result.status).toEqual('success')
+        expect(result.id).toEqual(orgId)
+      })
+
+      it('should call create organization with data', () => {
+        expect(mockedOrganizations.createOrganization).toHaveBeenCalledTimes(1)
+
+        expect(
+          mockedOrganizations.createOrganization.mock.calls[0]?.[1]?.input
+            ?.defaultCostCenter?.stateRegistration
+        ).toEqual(stateRegistration)
+      })
+
+      it('should save the user in store front permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.saveUser
+        ).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('with status APPROVED and without state registration', () => {
+      beforeEach(async () => {
+        mockedContext = mockContext()
+        result = await Organizations.updateOrganizationRequest(
+          jest.fn() as never,
+          input,
+          mockedContext
+        )
+      })
+
+      it('should return organization id with success', () => {
+        expect(result.status).toEqual('success')
+        expect(result.id).toEqual(orgId)
+      })
+
+      it('should call create organization without state registration', () => {
+        expect(mockedOrganizations.createOrganization).toHaveBeenCalledTimes(1)
+
+        expect(
+          mockedOrganizations.createOrganization.mock.calls[0]?.[1]?.input
+            ?.defaultCostCenter?.stateRegistration
+        ).toBeUndefined()
+      })
+
+      it('should save the user in store front permission', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.saveUser
+        ).toHaveBeenCalledTimes(1)
+      })
+    })
   })
+  describe('when create an organization', () => {
+    const orgId = randUuid()
 
-  describe('when update an organization with status APPROVED and state registration', () => {
-    const stateRegistration = randWord()
+    describe('with organization id and without cost center id', () => {
+      const costCenter = {
+        name: randLastName(),
+      }
 
-    beforeEach(async () => {
-      mockedContext = mockContext(stateRegistration)
-      result = await Organizations.updateOrganizationRequest(
-        jest.fn() as never,
-        input,
-        mockedContext
-      )
+      const defaultCostCenter = {
+        name: randSuperheroName(),
+      }
+
+      const input = {
+        b2bCustomerAdmin: {
+          email: randEmail(),
+          firstName: randFirstName(),
+        },
+        costCenters: [costCenter],
+        defaultCostCenter,
+        id: orgId,
+        name: randCompanyName(),
+        tradeName: randAirportName(),
+      } as OrganizationInput
+
+      let result: { href: any; organizationId: any }
+      let mockedContext: Context
+
+      const createDate = new Date('2020-01-01')
+
+      const roleId = randUuid()
+
+      jest.useFakeTimers().setSystemTime(createDate)
+
+      beforeEach(async () => {
+        mockedContext = mockContext(orgId, roleId)
+        result = await Organizations.createOrganizationAndCostCentersWithId(
+          jest.fn() as never,
+          { input },
+          mockedContext
+        )
+      })
+
+      it('should create the organization with the data expected', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(1, {
+          dataEntity: ORGANIZATION_DATA_ENTITY,
+          fields: {
+            collections: [],
+            created: createDate,
+            customFields: [],
+            id: orgId,
+            name: input.name,
+            status: 'active',
+            tradeName: input.tradeName,
+          },
+          schema: ORGANIZATION_SCHEMA_VERSION,
+        })
+      })
+      it('should create the cost center specified without set id', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(2, {
+          dataEntity: COST_CENTER_DATA_ENTITY,
+          fields: {
+            addresses: undefined,
+            organization: orgId,
+            ...costCenter,
+          },
+          schema: COST_CENTER_SCHEMA_VERSION,
+        })
+      })
+      it('should create the default cost center', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(3, {
+          dataEntity: COST_CENTER_DATA_ENTITY,
+          fields: {
+            addresses: undefined,
+            organization: orgId,
+            ...defaultCostCenter,
+          },
+          schema: COST_CENTER_SCHEMA_VERSION,
+        })
+      })
+      it('should set admin user for each cost center', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.saveUser
+        ).toBeCalledWith({
+          clId: null,
+          costId: undefined,
+          email: input.b2bCustomerAdmin.email,
+          name: `${input.b2bCustomerAdmin.firstName} ${input.b2bCustomerAdmin.lastName}`,
+          orgId,
+          roleId,
+        })
+      })
+      it('should create the organization with the id specified', () => {
+        expect(result.organizationId).toEqual(orgId)
+      })
     })
+    describe('with organization id and cost center id', () => {
+      const costCenter = {
+        id: randUuid(),
+        name: randLastName(),
+      }
 
-    it('should return organization id with success', () => {
-      expect(result.status).toEqual('success')
-      expect(result.id).toEqual(orgId)
-    })
+      const defaultCostCenter = {
+        id: randUuid(),
+        name: randSuperheroName(),
+      }
 
-    it('should call create organization with data', () => {
-      expect(mockedOrganizations.createOrganization).toHaveBeenCalledTimes(1)
+      const input = {
+        b2bCustomerAdmin: {
+          email: randEmail(),
+          firstName: randFirstName(),
+        },
+        costCenters: [costCenter],
+        defaultCostCenter,
+        id: orgId,
+        name: randCompanyName(),
+        tradeName: randAirportName(),
+      } as OrganizationInput
 
-      expect(
-        mockedOrganizations.createOrganization.mock.calls[0]?.[1]?.input
-          ?.defaultCostCenter?.stateRegistration
-      ).toEqual(stateRegistration)
-    })
+      let result: { href: any; organizationId: any }
+      let mockedContext: Context
 
-    it('should save the user in store front permission', () => {
-      expect(
-        mockedContext.clients.storefrontPermissions.saveUser
-      ).toHaveBeenCalledTimes(1)
-    })
-  })
+      const createDate = new Date('2020-01-01')
 
-  describe('when update an organization with status APPROVED and without state registration', () => {
-    beforeEach(async () => {
-      mockedContext = mockContext()
-      result = await Organizations.updateOrganizationRequest(
-        jest.fn() as never,
-        input,
-        mockedContext
-      )
-    })
+      const roleId = randUuid()
 
-    it('should return organization id with success', () => {
-      expect(result.status).toEqual('success')
-      expect(result.id).toEqual(orgId)
-    })
+      jest.useFakeTimers().setSystemTime(createDate)
 
-    it('should call create organization without state registration', () => {
-      expect(mockedOrganizations.createOrganization).toHaveBeenCalledTimes(1)
+      beforeEach(async () => {
+        mockedContext = mockContext(orgId, roleId)
+        result = await Organizations.createOrganizationAndCostCentersWithId(
+          jest.fn() as never,
+          { input },
+          mockedContext
+        )
+      })
 
-      expect(
-        mockedOrganizations.createOrganization.mock.calls[0]?.[1]?.input
-          ?.defaultCostCenter?.stateRegistration
-      ).toBeUndefined()
-    })
-
-    it('should save the user in store front permission', () => {
-      expect(
-        mockedContext.clients.storefrontPermissions.saveUser
-      ).toHaveBeenCalledTimes(1)
+      it('should create the organization with the data expected', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(1, {
+          dataEntity: ORGANIZATION_DATA_ENTITY,
+          fields: {
+            collections: [],
+            created: createDate,
+            customFields: [],
+            id: orgId,
+            name: input.name,
+            status: 'active',
+            tradeName: input.tradeName,
+          },
+          schema: ORGANIZATION_SCHEMA_VERSION,
+        })
+      })
+      it('should create the cost center specified without set id', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(2, {
+          dataEntity: COST_CENTER_DATA_ENTITY,
+          fields: {
+            addresses: undefined,
+            organization: orgId,
+            ...costCenter,
+          },
+          schema: COST_CENTER_SCHEMA_VERSION,
+        })
+      })
+      it('should create the default cost center', () => {
+        expect(
+          mockedContext.clients.masterdata.createDocument
+        ).toHaveBeenNthCalledWith(3, {
+          dataEntity: COST_CENTER_DATA_ENTITY,
+          fields: {
+            addresses: undefined,
+            organization: orgId,
+            ...defaultCostCenter,
+          },
+          schema: COST_CENTER_SCHEMA_VERSION,
+        })
+      })
+      it('should set admin user for each cost center', () => {
+        expect(
+          mockedContext.clients.storefrontPermissions.saveUser
+        ).toHaveBeenNthCalledWith(1, {
+          clId: null,
+          costId: costCenter.id,
+          email: input.b2bCustomerAdmin.email,
+          name: `${input.b2bCustomerAdmin.firstName} ${input.b2bCustomerAdmin.lastName}`,
+          orgId,
+          roleId,
+        })
+        expect(
+          mockedContext.clients.storefrontPermissions.saveUser
+        ).toHaveBeenNthCalledWith(2, {
+          clId: null,
+          costId: defaultCostCenter.id,
+          email: input.b2bCustomerAdmin.email,
+          name: `${input.b2bCustomerAdmin.firstName} ${input.b2bCustomerAdmin.lastName}`,
+          orgId,
+          roleId,
+        })
+      })
+      it('should create the organization with the id specified', () => {
+        expect(result.organizationId).toEqual(orgId)
+      })
     })
   })
 })

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -197,7 +197,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
 
     return {
       href: createOrganizationResult.Href,
-      organizationId: createOrganizationResult.DocumentId,
+      id: organizationId,
       status: '',
     }
   } catch (error) {
@@ -439,7 +439,7 @@ const Organizations = {
     ctx: Context
   ): Promise<{
     href: string
-    organizationId: string
+    id: string
   }> => {
     const {
       vtex: { logger },
@@ -450,12 +450,15 @@ const Organizations = {
 
     try {
       // create organization
-      const { href, organizationId } =
-        await createOrganizationAndCostCenterWithAdminUser(_, input, ctx)
+      const { href, id } = await createOrganizationAndCostCenterWithAdminUser(
+        _,
+        input,
+        ctx
+      )
 
       return {
         href,
-        organizationId,
+        id,
       }
     } catch (error) {
       logger.error({
@@ -650,7 +653,7 @@ const Organizations = {
     try {
       if (status === ORGANIZATION_REQUEST_STATUSES.APPROVED) {
         try {
-          const { organizationId } =
+          const { id: organizationId } =
             await createOrganizationAndCostCenterWithAdminUser(
               _,
               organizationRequest,

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -140,11 +140,13 @@ const createOrganizationAndCostCenterWithAdminUser = async (
     if (costCenters?.length) {
       await Promise.all(
         costCenters?.map(async (costCenter: DefaultCostCenterInput) => {
+          const addresses = costCenter.address ? [costCenter.address] : []
+
           CostCenterRepository.saveCostCenter(
             _,
             organizationId,
             {
-              addresses: [costCenter.address],
+              addresses,
               ...costCenter,
             },
             ctx
@@ -169,11 +171,15 @@ const createOrganizationAndCostCenterWithAdminUser = async (
     }
 
     if (defaultCostCenter) {
+      const addresses = defaultCostCenter.address
+        ? [defaultCostCenter.address]
+        : []
+
       await CostCenterRepository.saveCostCenter(
         _,
         organizationId,
         {
-          addresses: [defaultCostCenter.address],
+          addresses,
           ...defaultCostCenter,
         },
         ctx
@@ -254,25 +260,31 @@ const Organizations = {
 
       if (!defaultCostCenter && costCenters?.length) {
         costCenterResult = await Promise.all(
-          costCenters?.map(async (costCenter: any) =>
+          costCenters?.map(async (costCenter: any) => {
+            const addresses = costCenter.address ? [costCenter.address] : []
+
             CostCenterRepository.saveCostCenter(
               _,
               organizationId,
               {
-                addresses: [costCenter.address],
+                addresses,
                 ...costCenter,
               },
               ctx
             )
-          )
+          })
         )
       } else if (defaultCostCenter) {
+        const addresses = defaultCostCenter.address
+          ? [defaultCostCenter.address]
+          : []
+
         costCenterResult = [
           await CostCenterRepository.saveCostCenter(
             _,
             organizationId,
             {
-              addresses: [defaultCostCenter.address],
+              addresses,
               ...defaultCostCenter,
             },
             ctx

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -27,7 +27,7 @@ import {
 import checkConfig from '../config'
 import message from '../message'
 import B2BSettings from '../Queries/Settings'
-import CostCenters from './CostCenters'
+import CostCenterRepository from '../repository/CostCenterRepository'
 
 const createUserAndAttachToOrganization = async ({
   storefrontPermissions,
@@ -140,7 +140,15 @@ const createOrganizationAndCostCenterWithAdminUser = async (
     if (costCenters?.length) {
       await Promise.all(
         costCenters?.map(async (costCenter: DefaultCostCenterInput) => {
-          CostCenters.createCostCenter(_, organizationId, costCenter, ctx)
+          CostCenterRepository.saveCostCenter(
+            _,
+            organizationId,
+            {
+              addresses: [costCenter.address],
+              ...costCenter,
+            },
+            ctx
+          )
           const userToAdd = costCenter.user ?? {
             email,
             firstName,
@@ -161,10 +169,13 @@ const createOrganizationAndCostCenterWithAdminUser = async (
     }
 
     if (defaultCostCenter) {
-      await CostCenters.createCostCenter(
+      await CostCenterRepository.saveCostCenter(
         _,
         organizationId,
-        defaultCostCenter,
+        {
+          addresses: [defaultCostCenter.address],
+          ...defaultCostCenter,
+        },
         ctx
       )
       await createUserAndAttachToOrganization({
@@ -244,15 +255,26 @@ const Organizations = {
       if (!defaultCostCenter && costCenters?.length) {
         costCenterResult = await Promise.all(
           costCenters?.map(async (costCenter: any) =>
-            CostCenters.createCostCenter(_, organizationId, costCenter, ctx)
+            CostCenterRepository.saveCostCenter(
+              _,
+              organizationId,
+              {
+                addresses: [costCenter.address],
+                ...costCenter,
+              },
+              ctx
+            )
           )
         )
       } else if (defaultCostCenter) {
         costCenterResult = [
-          await CostCenters.createCostCenter(
+          await CostCenterRepository.saveCostCenter(
             _,
             organizationId,
-            defaultCostCenter,
+            {
+              addresses: [defaultCostCenter.address],
+              ...defaultCostCenter,
+            },
             ctx
           ),
         ]

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -142,7 +142,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         costCenters?.map(async (costCenter: DefaultCostCenterInput) => {
           const addresses = costCenter.address ? [costCenter.address] : []
 
-          CostCenterRepository.saveCostCenter(
+          CostCenterRepository.createCostCenter(
             _,
             organizationId,
             {
@@ -175,7 +175,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         ? [defaultCostCenter.address]
         : []
 
-      await CostCenterRepository.saveCostCenter(
+      await CostCenterRepository.createCostCenter(
         _,
         organizationId,
         {
@@ -263,7 +263,7 @@ const Organizations = {
           costCenters?.map(async (costCenter: any) => {
             const addresses = costCenter.address ? [costCenter.address] : []
 
-            CostCenterRepository.saveCostCenter(
+            CostCenterRepository.createCostCenter(
               _,
               organizationId,
               {
@@ -280,7 +280,7 @@ const Organizations = {
           : []
 
         costCenterResult = [
-          await CostCenterRepository.saveCostCenter(
+          await CostCenterRepository.createCostCenter(
             _,
             organizationId,
             {

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -1,5 +1,6 @@
 import GraphQLError from '../../utils/GraphQLError'
 import checkConfig, { getAppId } from '../config'
+import type { B2BSettingsInput } from '../../typings'
 
 export const B2B_SETTINGS_DOCUMENT_ID = 'b2bSettings'
 

--- a/node/resolvers/Mutations/Users.test.ts
+++ b/node/resolvers/Mutations/Users.test.ts
@@ -2,6 +2,7 @@ import { randAlphaNumeric, randEmail, randUser, randUuid } from '@ngneat/falso'
 import { GraphQLError } from 'graphql'
 
 import Users from './Users'
+import type { UserArgs } from '../../typings'
 
 jest.mock('../config')
 jest.mock('../../utils/metrics/impersonate')

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -10,6 +10,7 @@ import {
   sendRemoveUserMetric,
   sendUpdateUserMetric,
 } from '../../utils/metrics/user'
+import type { UserArgs } from '../../typings'
 
 export const getUserRoleSlug: (
   id: string,

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -4,6 +4,7 @@ import {
   COST_CENTER_FIELDS,
   COST_CENTER_SCHEMA_VERSION,
 } from '../../mdSchema'
+import type { Address, CostCenter } from '../../typings'
 import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import checkConfig from '../config'
 import Organizations from './Organizations'

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -1,3 +1,4 @@
+import type { B2BSettingsInput } from '../../typings'
 import GraphQLError from '../../utils/GraphQLError'
 import checkConfig from '../config'
 

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -1,6 +1,6 @@
-import type { B2BSettingsInput } from '../../typings'
 import GraphQLError from '../../utils/GraphQLError'
 import checkConfig from '../config'
+import type { B2BSettingsInput } from '../../typings'
 
 const B2BSettings = {
   getB2BSettings: async (_: void, __: void, ctx: Context) => {

--- a/node/resolvers/fieldResolvers.ts
+++ b/node/resolvers/fieldResolvers.ts
@@ -5,6 +5,7 @@ import {
   ORGANIZATION_FIELDS,
 } from '../mdSchema'
 import GraphQLError, { getErrorMessage } from '../utils/GraphQLError'
+import type { CostCenter, Organization } from '../typings'
 
 export const organizationName = async (
   { orgId }: { orgId: string },

--- a/node/resolvers/repository/CostCenterRepository.ts
+++ b/node/resolvers/repository/CostCenterRepository.ts
@@ -1,0 +1,71 @@
+import type { CostCenterInput, Result } from '../../typings'
+import {
+  COST_CENTER_DATA_ENTITY,
+  COST_CENTER_SCHEMA_VERSION,
+} from '../../mdSchema'
+import MarketingTags from '../Mutations/MarketingTags'
+
+const CostCenterRepository = {
+  saveCostCenter: async (
+    _: void,
+    organizationId: string,
+    {
+      addresses,
+      id,
+      name,
+      paymentTerms,
+      phoneNumber,
+      businessDocument,
+      stateRegistration,
+      customFields,
+      sellers,
+      marketingTags,
+    }: CostCenterInput,
+    ctx: Context
+  ): Promise<Result> => {
+    const {
+      clients: { masterdata },
+      vtex: { logger },
+    } = ctx
+
+    const costCenter = {
+      addresses,
+      id,
+      name,
+      organization: organizationId,
+      ...(paymentTerms && { paymentTerms }),
+      ...(phoneNumber && { phoneNumber }),
+      ...(businessDocument && { businessDocument }),
+      ...(stateRegistration && { stateRegistration }),
+      ...(customFields && { customFields }),
+      ...(sellers && { sellers }),
+    }
+
+    const createCostCenterResult = await masterdata.createDocument({
+      dataEntity: COST_CENTER_DATA_ENTITY,
+      fields: costCenter,
+      schema: COST_CENTER_SCHEMA_VERSION,
+    })
+
+    if (marketingTags && marketingTags?.length > 0) {
+      MarketingTags.setMarketingTags(
+        _,
+        { costId: createCostCenterResult.DocumentId, tags: marketingTags },
+        ctx
+      ).catch((error) => {
+        logger.error({
+          error,
+          message: 'setMarketingTags-error',
+        })
+      })
+    }
+
+    return {
+      href: createCostCenterResult.Href,
+      id: createCostCenterResult.DocumentId,
+      status: '',
+    }
+  },
+}
+
+export default CostCenterRepository

--- a/node/resolvers/repository/CostCenterRepository.ts
+++ b/node/resolvers/repository/CostCenterRepository.ts
@@ -6,7 +6,7 @@ import {
 import MarketingTags from '../Mutations/MarketingTags'
 
 const CostCenterRepository = {
-  saveCostCenter: async (
+  createCostCenter: async (
     _: void,
     organizationId: string,
     {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -1,3 +1,5 @@
+import type { Logger } from '@vtex/api/lib/service/logger/logger'
+
 interface ReqContext {
   account: string
   workspace: string
@@ -5,10 +7,6 @@ interface ReqContext {
   region: string
   production: boolean
   userAgent: string
-}
-
-interface Logger {
-  log(content: string, level: LogLevel, details?: any): PromiseLike<void>
 }
 
 interface OperationState {
@@ -43,6 +41,7 @@ interface Seller {
 }
 
 interface OrganizationInput {
+  id?: string
   name: string
   tradeName?: string
   b2bCustomerAdmin: B2BCustomerInput
@@ -62,6 +61,7 @@ interface B2BCustomerInput {
 }
 
 interface DefaultCostCenterInput {
+  id?: string
   name: string
   address: AddressInput
   phoneNumber?: string
@@ -70,9 +70,11 @@ interface DefaultCostCenterInput {
   stateRegistration?: string
   sellers?: Seller[]
   marketingTags?: string[]
+  user?: B2BUserInput
 }
 
 interface CostCenterInput {
+  id?: string
   name: string
   addresses?: AddressInput[]
   paymentTerms?: PaymentTerm[]
@@ -241,4 +243,10 @@ interface B2BSettingsInput {
   organizationCustomFields: CustomFieldSetting[]
   costCenterCustomFields: CustomFieldSetting[]
   transactionEmailSettings: TransactionEmailSetting
+}
+
+interface Result {
+  href: string
+  id: string
+  status: string
 }

--- a/node/utils/metrics/organization.test.ts
+++ b/node/utils/metrics/organization.test.ts
@@ -24,6 +24,12 @@ import {
   sendOrganizationStatusMetric,
   sendUpdateOrganizationMetric,
 } from './organization'
+import type {
+  Collection,
+  CustomField,
+  Organization,
+  PaymentTerm,
+} from '../../typings'
 
 jest.mock('./metrics')
 afterEach(() => {

--- a/node/utils/metrics/organization.ts
+++ b/node/utils/metrics/organization.ts
@@ -3,6 +3,7 @@ import { isEqual } from 'lodash'
 
 import type { Metric } from './metrics'
 import { B2B_METRIC_NAME, sendMetric } from './metrics'
+import type { Organization } from '../../typings'
 
 interface UpdateOrganizationFieldsMetric {
   update_details: { properties: string[] }

--- a/node/utils/metrics/user.test.ts
+++ b/node/utils/metrics/user.test.ts
@@ -7,6 +7,7 @@ import {
   sendRemoveUserMetric,
   sendUpdateUserMetric,
 } from './user'
+import type { UserArgs } from '../../typings'
 
 jest.mock('./metrics')
 afterEach(() => {

--- a/node/utils/metrics/user.ts
+++ b/node/utils/metrics/user.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Metric } from './metrics'
 import { B2B_METRIC_NAME, sendMetric } from './metrics'
+import type { UserArgs } from '../../typings'
 
 interface UserMetricType {
   description: string


### PR DESCRIPTION
#### What problem is this solving?

We need to create a new endpoint to use in bulk import to create an organization and cost center with a specific ID.

#### How to test it?

- Call the CURL in the workspace
```CURL
curl --location 'https://createorg--b2bsuite.myvtex.com/_v/private/graphql/v1' \
--header 'Cookie: <YOUR_COOKIE>' \
--header 'Content-Type: application/json' \
--data-raw '{"query":"mutation CreateOrganization($input: OrganizationInput!) {\n  createOrganizationAndCostCentersWithId(input: $input)\n    @context(provider: \"vtex.b2b-organizations-graphql\") {\n    id\n  }\n}","variables":{"input":{"id":"12345678","name":"Org Test 12345678","customFields":[],"defaultCostCenter":{"id":"12345678","name":"First","address":{"addressId":"0","addressType":"residential","city":"São Paulo","complement":null,"country":"BRA","receiverName":"principal","geoCoordinates":[-46.630714416503906,-23.55284881591797],"neighborhood":"Sé","number":"1","postalCode":"01001-000","reference":null,"state":"SP","street":"Praça da Sé","addressQuery":""},"phoneNumber":"","businessDocument":"","customFields":[],"stateRegistration":""},"b2bCustomerAdmin":{"email":"test+12345678@vtex.com.br","firstName":"Test","lastName":"12345678"}}}}'
```

[Workspace](https://createorg--b2bsuite.myvtex.com/admin)

#### Screenshots or example usage:

<img width="1011" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/39575949-de50-4453-bc2a-9360a6966b52">

#### Describe alternatives you've considered, if any.

I tried not to change the existing code, but I preferred to centralize the implementation to create organization and cost center.