### PR TITLE
feat: fallback to get an admin token on the header instead of a cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- fallback to check an admin token on the header
+
 ## [0.42.0] - 2023-10-13
 
 ### Added

--- a/node/resolvers/directives/checkAdminAccess.ts
+++ b/node/resolvers/directives/checkAdminAccess.ts
@@ -18,7 +18,8 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
         clients: { identity },
       } = context
 
-      let token = adminUserAuthToken
+      let token =
+        adminUserAuthToken ?? (context?.headers.vtexidclientautcookie as string)
 
       const apiToken = context?.headers['vtex-api-apptoken'] as string
       const appKey = context?.headers['vtex-api-appkey'] as string


### PR DESCRIPTION
#### What problem is this solving?

When the API is called by Dandelion and Bulk-Import auth token isn't found.

#### How to test it?

- For Bulk-import
- Call the endpoint Upload file `/api/b2b/import/buyer-orgs?an={{accountName}}` and send the file
- Call the endpoint Start Import `api/b2b/import/buyer-orgs/`

[Workspace](https://createorg--b2bstoreqa.myvtex.com/admin)

#### Describe alternatives you've considered, if any.

We could use the cookie, but at the moment the bulk-import just works with the header `VtexIdclientAutCookie`.
