### PR TITLE
fix: use cost center ID created on approve organization request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- use cost center ID created on approve organization request
+
 ## [0.43.0] - 2023-10-20
 
 ### Added

--- a/node/resolvers/Mutations/Organizations.test.ts
+++ b/node/resolvers/Mutations/Organizations.test.ts
@@ -41,15 +41,21 @@ const mockGetDocument = jest.fn().mockResolvedValue({
 } as OrganizationRequest)
 
 const mockContext = (
-  createdId: string = randUuid(),
-  roleId: string = randUuid()
+  orgId: string = randUuid(),
+  roleId: string = randUuid(),
+  costId: string = randUuid()
 ) => {
   return {
     clients: {
       masterdata: {
-        createDocument: jest.fn().mockResolvedValue({
-          DocumentId: createdId,
-        }),
+        createDocument: jest
+          .fn()
+          .mockResolvedValueOnce({
+            DocumentId: orgId,
+          })
+          .mockResolvedValue({
+            DocumentId: costId,
+          }),
         getDocument: mockGetDocument,
         searchDocuments: jest.fn().mockResolvedValue({}),
         updatePartialDocument: jest.fn().mockResolvedValueOnce({}),
@@ -225,12 +231,13 @@ describe('given an Organization Mutation', () => {
       let mockedContext: Context
 
       const roleId = randUuid()
+      const costId = randUuid()
 
       const createDate = new Date('2020-01-01')
 
       beforeEach(async () => {
         jest.useFakeTimers().setSystemTime(createDate)
-        mockedContext = mockContext(orgId, roleId)
+        mockedContext = mockContext(orgId, roleId, costId)
         result = await Organizations.createOrganizationAndCostCentersWithId(
           jest.fn() as never,
           { input },
@@ -287,7 +294,7 @@ describe('given an Organization Mutation', () => {
           mockedContext.clients.storefrontPermissions.saveUser
         ).toBeCalledWith({
           clId: null,
-          costId: undefined,
+          costId,
           email: input.b2bCustomerAdmin.email,
           name: `${input.b2bCustomerAdmin.firstName} ${input.b2bCustomerAdmin.lastName}`,
           orgId,
@@ -299,13 +306,14 @@ describe('given an Organization Mutation', () => {
       })
     })
     describe('with organization id and cost center id', () => {
+      const costId = randUuid()
       const costCenter = {
-        id: randUuid(),
+        id: costId,
         name: randLastName(),
       }
 
       const defaultCostCenter = {
-        id: randUuid(),
+        id: costId,
         name: randSuperheroName(),
       }
 
@@ -330,7 +338,7 @@ describe('given an Organization Mutation', () => {
 
       beforeEach(async () => {
         jest.useFakeTimers().setSystemTime(createDate)
-        mockedContext = mockContext(orgId, roleId)
+        mockedContext = mockContext(orgId, roleId, costId)
         result = await Organizations.createOrganizationAndCostCentersWithId(
           jest.fn() as never,
           { input },

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -142,15 +142,17 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         costCenters?.map(async (costCenter: DefaultCostCenterInput) => {
           const addresses = costCenter.address ? [costCenter.address] : []
 
-          CostCenterRepository.createCostCenter(
-            _,
-            organizationId,
-            {
-              addresses,
-              ...costCenter,
-            },
-            ctx
-          )
+          const { id: costCenterId } =
+            await CostCenterRepository.createCostCenter(
+              _,
+              organizationId,
+              {
+                addresses,
+                ...costCenter,
+              },
+              ctx
+            )
+
           const userToAdd = costCenter.user ?? {
             email,
             firstName,
@@ -158,7 +160,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
           }
 
           createUserAndAttachToOrganization({
-            costCenterId: costCenter.id,
+            costCenterId,
             email: userToAdd.email,
             firstName: userToAdd.firstName,
             lastName: userToAdd.lastName,
@@ -175,7 +177,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         ? [defaultCostCenter.address]
         : []
 
-      await CostCenterRepository.createCostCenter(
+      const { id: costCenterId } = await CostCenterRepository.createCostCenter(
         _,
         organizationId,
         {
@@ -184,8 +186,9 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         },
         ctx
       )
+
       await createUserAndAttachToOrganization({
-        costCenterId: defaultCostCenter.id,
+        costCenterId,
         email,
         firstName,
         lastName,


### PR DESCRIPTION
#### What problem is this solving?

After requesting an organization creation, the admin user was without a cost center.

#### How to test it?

- Request an organization creation.
- Fill admin user
- Approve the organization.

[Workspace](https://tkt926539--b2bsuite.myvtex.com/)
