### PR TITLE
Fix the costCenterId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix costCenterId null in the response when using 'createOrganization' mutation
+
 ## [0.43.1] - 2023-10-27
 
 ### Fixed

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -313,7 +313,7 @@ const Organizations = {
       }
 
       return {
-        costCenterId: costCenterResult[0].DocumentId,
+        costCenterId: costCenterResult[0].id,
         href: createOrganizationResult.Href,
         id: createOrganizationResult.DocumentId,
         status: '',


### PR DESCRIPTION
Fix the costCenterId when using mutation createOrganization

#### What problem is this solving?

When using the createOrganization mutation, there is no costCenterId returned in the response:

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/90935861/2ad1626d-79d2-4b0a-aade-2070db8adc2e)

#### How to test it?

- Access the graphQL IDE in [internal account](https://tkt928918--b2bsuite.myvtex.com/admin/graphql-ide)
- Create a organization using createOrganization mutation

#### Screenshots or example usage:

- Before
![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/90935861/2ad1626d-79d2-4b0a-aade-2070db8adc2e)

-After
![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/90935861/6564564c-74e9-4a25-b2f4-f0be1c3da95f)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
