### PR TITLE
feat: allow create cost center with an user provided id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- allow creation of cost center with an user provided id
+
 ## [0.44.0] - 2023-11-06
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -489,6 +489,7 @@ input DefaultCostCenterInput {
 }
 
 input CostCenterInput {
+  id: String
   name: String
   addresses: [AddressInput]
   paymentTerms: [PaymentTermInput]

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -131,6 +131,12 @@ type Mutation {
     @withPermissions
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
+  createCostCenterWithId(
+    organizationId: ID
+    input: CostCenterInput!
+  ): MasterDataResponse
+    @checkAdminAccess
+    @cacheControl(scope: PRIVATE)
   updateOrganization(
     id: ID!
     name: String!

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
   "version": "0.44.0",
   "dependencies": {
     "@types/lodash": "4.14.74",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.46.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.46.0",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -13,6 +13,7 @@ const CostCenters = {
     {
       organizationId,
       input: {
+        id,
         name,
         addresses,
         phoneNumber,
@@ -58,6 +59,7 @@ const CostCenters = {
         businessDocument,
         customFields,
         marketingTags,
+        id,
         name,
         phoneNumber,
         sellers,

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -2,10 +2,14 @@ import {
   COST_CENTER_DATA_ENTITY,
   ORGANIZATION_DATA_ENTITY,
 } from '../../mdSchema'
-import type { AddressInput, CostCenterInput, CostCenterInputWithId } from '../../typings'
+import type {
+  AddressInput,
+  CostCenterInput,
+  CostCenterInputWithId,
+} from '../../typings'
 import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import Organizations from '../Queries/Organizations'
-import costCenters from "../Queries/CostCenters"
+import costCenters from '../Queries/CostCenters'
 import checkConfig from '../config'
 import CostCenterRepository from '../repository/CostCenterRepository'
 
@@ -118,14 +122,12 @@ const CostCenters = {
     }
 
     // check if cost center id already exists
-    var costCenter = null
+    let costCenter = null
     try {
-      costCenter = (await costCenters.getCostCenterById(
-        _,
-        { id: id },
-        ctx
-      ))
-    } catch (error) { } // cost center does not exist so we don't need to do anything
+      costCenter = await costCenters.getCostCenterById(_, { id }, ctx)
+    } catch (error) {
+      costCenter = null // cost center does not exist so we don't need to do anything
+    }
 
     if (costCenter) {
       throw new Error('Cost Center already exists')

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -87,6 +87,20 @@ interface CostCenterInput {
   sellers?: Seller[]
 }
 
+interface CostCenterInputWithId {
+  id: string
+  name: string
+  addresses?: AddressInput[]
+  paymentTerms?: PaymentTerm[]
+  phoneNumber?: string
+  businessDocument?: string
+  customFields?: CustomField[]
+  stateRegistration?: string
+  marketingTags?: string[]
+  user?: B2BCustomerInput
+  sellers?: Seller[]
+}
+
 interface AddressInput {
   addressId: string
   addressType: string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -836,10 +836,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.22":
-  version "6.45.22"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
-  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
+"@vtex/api@6.46.0":
+  version "6.46.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
+  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?
The existing `createCostCenter` graphql API does not allow creating a cost center with an user provided id. This PR allows that. This API still works without providing an ID, so the admin UI use case should not break.

This will allow us to create cost centers with user provided ids on the bulk import application.

#### How to test it?
1. Create a new cost center using the admin UI. It should work as before (and id will be automatically created for the cost center).
2. Call the `createCostCenter` graphql api providing the cost center id. It should also work if the id is not provided. The request looks like this:
```
curl --location 'https://b2bteam1399--b2bstoreqa.myvtex.com/_v/private/graphql/v1' \
--header 'Cookie: VtexIdclientAutCookie=<cookie>; janus_sid=1e52fe67-97ef-4793-9c3d-e6075f17a2e0' \
--header 'Content-Type: application/json' \
--data-raw '{"query":"mutation CreateCostCenter($organizationId: ID, $input: CostCenterInput!) {\n  createCostCenter(organizationId: $organizationId, input: $input)\n    @context(provider: \"vtex.b2b-organizations-graphql\") {\n    id\n  }\n}","variables":{
  "organizationId": "enzo-org-test",
  "input": {
    "id": "third-cost-center-id"
    "name": "Third",
    "addresses": [{
    "addressId": "0",
    "addressType": "residential",
    "city": "São Paulo",
    "complement": null,
    "country": "BRA",
    "receiverName": "principal",
    "geoCoordinates": [
        -46.630714416503906,
        -23.55284881591797
    ],
    "neighborhood": "Sé",
    "number": "1",
    "postalCode": "01001-000",
    "reference": null,
    "state": "SP",
    "street": "Praça da Sé",
    "addressQuery": ""
    }],
    "phoneNumber": "",
    "businessDocument": "",
    "customFields": [],
    "stateRegistration": ""
  }
}}'
```

And here is the expected response when providing the id:
```
{
    "data": {
        "createCostCenter": {
            "id": "third-cost-center-id"
        }
    }
}
```

and when not providing the id it should look like this:
```
{
    "data": {
        "createCostCenter": {
            "id": "fcd4957d-7e46-11ee-83ab-12ecbcbe50e3"
        }
    }
}
```
[Workspace](https://b2bteam1399--b2bstoreqa.myvtex.com/admin)
