### PR TITLE
fix: remove get roles from metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove get permissions from access audit metrics
+
 ## [0.44.0] - 2023-11-06
 
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

We are exceeding the limit of calls from the app to VBase. It is because we are using `checkPermission` to get the role and all permissions of the user, and this function calls any others that save data in VBase.

#### How to test it?

- Call the operation using the directive `@auditAccess`

[Workspace](https://securitymetrics--b2bsuite.myvtex.com/)
