### PR TITLE
feat: add new directive to validate auth token with feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- add new directive to validate auth token, with feature flag to enable the validation
+
 ## [0.44.1] - 2023-11-09
 
 ### Fixed

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -3,3 +3,4 @@ directive @withPermissions on FIELD | FIELD_DEFINITION
 directive @checkUserAccess on FIELD | FIELD_DEFINITION
 directive @checkAdminAccess on FIELD | FIELD_DEFINITION
 directive @auditAccess on FIELD | FIELD_DEFINITION
+directive @checkAccessWithFeatureFlag on FIELD | FIELD_DEFINITION

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,7 +17,10 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): OrganizationResult @cacheControl(scope: PUBLIC, maxAge: SHORT) @auditAccess
+  ): OrganizationResult
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
+    @checkAccessWithFeatureFlag
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
@@ -25,10 +28,12 @@ type Query {
   getOrganizationById(id: ID): Organization
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getCostCenters(
     search: String
     page: Int = 1
@@ -43,7 +48,10 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): CostCenterResult @cacheControl(scope: PUBLIC, maxAge: SHORT) @auditAccess
+  ): CostCenterResult
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
+    @checkAccessWithFeatureFlag
   getCostCentersByOrganizationIdStorefront(
     id: ID
     search: String
@@ -55,10 +63,12 @@ type Query {
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getUsers(organizationId: ID, costCenterId: ID): [B2BUser]
     @withSession
     @checkUserAccess
@@ -78,26 +88,30 @@ type Query {
   getPaymentTerms: [PaymentTerm]
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
-
+    @checkAccessWithFeatureFlag
   getOrganizationsByEmail(email: String): [B2BOrganization]
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
     @auditAccess
-
+    @checkAccessWithFeatureFlag
   checkOrganizationIsActive(id: String): Boolean @cacheControl(scope: PRIVATE)
   getSalesChannels: [Channels]
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getBinding(email: String!): Boolean
     @withSession
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getMarketingTags(costId: ID!): MarketingTags
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getB2BSettings: B2BSettings
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
+    @checkAccessWithFeatureFlag
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -241,10 +241,12 @@ type Mutation {
     @withSession
     @withPermissions
     @cacheControl(scope: PRIVATE)
+    @auditAccess
   impersonateB2BUser(id: ID!): MutationResponse
     @withSession
     @withPermissions
     @cacheControl(scope: PRIVATE)
+    @auditAccess
   saveSalesChannels(channels: [SalesChannelsInput]!): MutationResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -93,7 +93,6 @@ type Query {
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
     @auditAccess
-    @checkAccessWithFeatureFlag
   checkOrganizationIsActive(id: String): Boolean @cacheControl(scope: PRIVATE)
   getSalesChannels: [Channels]
     @cacheControl(scope: PUBLIC, maxAge: SHORT)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -247,6 +247,7 @@ type Mutation {
     @withPermissions
     @cacheControl(scope: PRIVATE)
     @auditAccess
+    @checkAccessWithFeatureFlag
   saveSalesChannels(channels: [SalesChannelsInput]!): MutationResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
   "version": "0.44.1",
   "dependencies": {
     "@types/lodash": "4.14.74",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.46.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.46.0",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/resolvers/directives.ts
+++ b/node/resolvers/directives.ts
@@ -1,13 +1,15 @@
-import { WithSession } from './directives/withSession'
-import { WithPermissions } from './directives/withPermissions'
+import { AuditAccess } from './directives/auditAccess'
+import { CheckAccessWithFeatureFlag } from './directives/checkAccessWithFeatureFlag'
 import { CheckAdminAccess } from './directives/checkAdminAccess'
 import { CheckUserAccess } from './directives/checkUserAccess'
-import { AuditAccess } from './directives/auditAccess'
+import { WithPermissions } from './directives/withPermissions'
+import { WithSession } from './directives/withSession'
 
 export const schemaDirectives = {
+  auditAccess: AuditAccess as any,
+  checkAccessWithFeatureFlag: CheckAccessWithFeatureFlag as any,
   checkAdminAccess: CheckAdminAccess as any,
   checkUserAccess: CheckUserAccess as any,
   withPermissions: WithPermissions as any,
   withSession: WithSession as any,
-  auditAccess: AuditAccess as any,
 }

--- a/node/resolvers/directives/checkAccessWithFeatureFlag.ts
+++ b/node/resolvers/directives/checkAccessWithFeatureFlag.ts
@@ -1,7 +1,8 @@
-import { AuthenticationError, ForbiddenError } from '@vtex/api'
 import type { GraphQLField } from 'graphql'
 import { defaultFieldResolver } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+import { checkUserOrAdminTokenAccess } from './checkUserAccess'
 
 export class CheckAccessWithFeatureFlag extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
@@ -14,8 +15,8 @@ export class CheckAccessWithFeatureFlag extends SchemaDirectiveVisitor {
       info: any
     ) => {
       const {
-        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
-        clients: { identity, vtexId, masterdata },
+        vtex: { adminUserAuthToken },
+        clients: { masterdata },
       } = context
 
       const config: { enable: boolean } = await masterdata.getDocument({
@@ -25,46 +26,7 @@ export class CheckAccessWithFeatureFlag extends SchemaDirectiveVisitor {
       })
 
       if (config?.enable) {
-        const token =
-          adminUserAuthToken ??
-          (context?.headers.vtexidclientautcookie as string)
-
-        if (!token && !storeUserAuthToken) {
-          throw new AuthenticationError('No admin or store token was provided')
-        }
-
-        if (token) {
-          try {
-            await identity.validateToken({ token })
-          } catch (err) {
-            logger.warn({
-              error: err,
-              message: 'CheckUserAccess: Invalid admin token',
-              token,
-            })
-            throw new ForbiddenError('Unauthorized Access')
-          }
-        } else if (storeUserAuthToken) {
-          let authUser = null
-
-          try {
-            authUser = await vtexId.getAuthenticatedUser(storeUserAuthToken)
-            if (!authUser?.user) {
-              authUser = null
-            }
-          } catch (err) {
-            logger.warn({
-              error: err,
-              message: 'CheckUserAccess: Invalid store user token',
-              token: storeUserAuthToken,
-            })
-            authUser = null
-          }
-
-          if (!authUser) {
-            throw new ForbiddenError('Unauthorized Access')
-          }
-        }
+        await checkUserOrAdminTokenAccess(context, adminUserAuthToken)
       }
 
       return resolve(root, args, context, info)

--- a/node/resolvers/directives/checkAccessWithFeatureFlag.ts
+++ b/node/resolvers/directives/checkAccessWithFeatureFlag.ts
@@ -22,7 +22,7 @@ export class CheckAccessWithFeatureFlag extends SchemaDirectiveVisitor {
       const config: { enable: boolean } = await masterdata.getDocument({
         dataEntity: 'auth_validation_config',
         fields: ['enable'],
-        id: 'config',
+        id: 'b2b-organizations-graphql',
       })
 
       if (config?.enable) {

--- a/node/resolvers/directives/checkAccessWithFeatureFlag.ts
+++ b/node/resolvers/directives/checkAccessWithFeatureFlag.ts
@@ -1,0 +1,73 @@
+import { AuthenticationError, ForbiddenError } from '@vtex/api'
+import type { GraphQLField } from 'graphql'
+import { defaultFieldResolver } from 'graphql'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+export class CheckAccessWithFeatureFlag extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (
+      root: any,
+      args: any,
+      context: Context,
+      info: any
+    ) => {
+      const {
+        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
+        clients: { identity, vtexId, masterdata },
+      } = context
+
+      const config: { enable: boolean } = await masterdata.getDocument({
+        dataEntity: 'auth_validation_config',
+        fields: ['enable'],
+        id: 'config',
+      })
+
+      if (config?.enable) {
+        const token =
+          adminUserAuthToken ??
+          (context?.headers.vtexidclientautcookie as string)
+
+        if (!token && !storeUserAuthToken) {
+          throw new AuthenticationError('No admin or store token was provided')
+        }
+
+        if (token) {
+          try {
+            await identity.validateToken({ token })
+          } catch (err) {
+            logger.warn({
+              error: err,
+              message: 'CheckUserAccess: Invalid admin token',
+              token,
+            })
+            throw new ForbiddenError('Unauthorized Access')
+          }
+        } else if (storeUserAuthToken) {
+          let authUser = null
+
+          try {
+            authUser = await vtexId.getAuthenticatedUser(storeUserAuthToken)
+            if (!authUser?.user) {
+              authUser = null
+            }
+          } catch (err) {
+            logger.warn({
+              error: err,
+              message: 'CheckUserAccess: Invalid store user token',
+              token: storeUserAuthToken,
+            })
+            authUser = null
+          }
+
+          if (!authUser) {
+            throw new ForbiddenError('Unauthorized Access')
+          }
+        }
+      }
+
+      return resolve(root, args, context, info)
+    }
+  }
+}

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -1,7 +1,54 @@
-import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { AuthenticationError, ForbiddenError } from '@vtex/api'
 import type { GraphQLField } from 'graphql'
 import { defaultFieldResolver } from 'graphql'
-import { AuthenticationError, ForbiddenError } from '@vtex/api'
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+
+export async function checkUserOrAdminTokenAccess(
+  ctx: Context,
+  token?: string
+) {
+  const {
+    vtex: { storeUserAuthToken, logger },
+    clients: { identity, vtexId },
+  } = ctx
+
+  if (!token && !storeUserAuthToken) {
+    throw new AuthenticationError('No admin or store token was provided')
+  }
+
+  if (token) {
+    try {
+      await identity.validateToken({ token })
+    } catch (err) {
+      logger.warn({
+        error: err,
+        message: 'CheckUserAccess: Invalid admin token',
+        token,
+      })
+      throw new ForbiddenError('Unauthorized Access')
+    }
+  } else if (storeUserAuthToken) {
+    let authUser = null
+
+    try {
+      authUser = await vtexId.getAuthenticatedUser(storeUserAuthToken)
+      if (!authUser?.user) {
+        authUser = null
+      }
+    } catch (err) {
+      logger.warn({
+        error: err,
+        message: 'CheckUserAccess: Invalid store user token',
+        token: storeUserAuthToken,
+      })
+      authUser = null
+    }
+
+    if (!authUser) {
+      throw new ForbiddenError('Unauthorized Access')
+    }
+  }
+}
 
 export class CheckUserAccess extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
@@ -14,8 +61,8 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
       info: any
     ) => {
       const {
-        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
-        clients: { identity, vtexId },
+        vtex: { adminUserAuthToken },
+        clients: { identity },
       } = context
 
       let token = adminUserAuthToken
@@ -31,42 +78,7 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         context.vtex.adminUserAuthToken = token
       }
 
-      if (!token && !storeUserAuthToken) {
-        throw new AuthenticationError('No admin or store token was provided')
-      }
-
-      if (token) {
-        try {
-          await identity.validateToken({ token })
-        } catch (err) {
-          logger.warn({
-            error: err,
-            message: 'CheckUserAccess: Invalid admin token',
-            token,
-          })
-          throw new ForbiddenError('Unauthorized Access')
-        }
-      } else if (storeUserAuthToken) {
-        let authUser = null
-
-        try {
-          authUser = await vtexId.getAuthenticatedUser(storeUserAuthToken)
-          if (!authUser?.user) {
-            authUser = null
-          }
-        } catch (err) {
-          logger.warn({
-            error: err,
-            message: 'CheckUserAccess: Invalid store user token',
-            token: storeUserAuthToken,
-          })
-          authUser = null
-        }
-
-        if (!authUser) {
-          throw new ForbiddenError('Unauthorized Access')
-        }
-      }
+      await checkUserOrAdminTokenAccess(context, token)
 
       return resolve(root, args, context, info)
     }

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
-const ANALYTICS_URL = 'https://rc.vtex.com/api/analytics/schemaless-events'
+const ANALYTICS_URL =
+  'https://analytics.vtex.com/api/analytics/schemaless-events'
 
 export const B2B_METRIC_NAME = 'b2b-suite-buyerorg-data'
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -836,10 +836,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.22":
-  version "6.45.22"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
-  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
+"@vtex/api@6.46.0":
+  version "6.46.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
+  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

Enable the auth token validation for insecure operations. Previously, we put the directive `@auditAccess` and now we add the directive `@checkAccessWithFeatureFlag`.

#### How to test it?

- Configure the feature flag in masterdata
```CURL
curl --location 'https://tokenvalidation--b2bsuite.vtexcommercestable.com.br/api/dataentities/auth_validation_config/documents' \
--header 'VtexIdclientAutCookie: {{TOKEN}}' \
--header 'Content-Type: application/json' \
--data '{
    "id": "b2b-organizations-graphql",
    "enable": false
 }
'
```
- Update the config
```CURL
curl --location --request PATCH 'https://tokenvalidation--b2bsuite.vtexcommercestable.com.br/api/dataentities/auth_validation_config/documents/b2b-organizations-graphql' \
--header 'VtexIdclientAutCookie: {{token}}' \
--header 'Content-Type: application/json' \
--data '{
    "enable": true
 }
'
```
- Call an operation that has the new directive.
- We called the `getOrganizationByIdStorefront` in the performance test and the difference between them was 100 ms for average, 90 ms for mediana, and 160 ms for P95.

  scenarios: (100.00%) 1 scenario, 2 max VUs, 45s max duration (incl. graceful stop):
           * default: 2 looping VUs for 15s (gracefulStop: 30s)

- Performance test without querying masterdata to get the feature flag:

```
 checks.........................: 100.00% ✓ 68       ✗ 0
 data_received..................: 104 kB  6.8 kB/s
 data_sent......................: 281 kB  18 kB/s
 http_req_blocked...............: avg=1.39ms   min=0s       med=0s       max=48.89ms p(90)=1µs      p(95)=1µs
 http_req_connecting............: avg=199.76µs min=0s       med=0s       max=6.79ms  p(90)=0s       p(95)=0s
 http_req_duration..............: avg=447.16ms min=283.85ms med=334.7ms  max=2.01s   p(90)=678.68ms p(95)=846.22ms
   { expected_response:true }...: avg=447.16ms min=283.85ms med=334.7ms  max=2.01s   p(90)=678.68ms p(95)=846.22ms
 http_req_failed................: 0.00%   ✓ 0        ✗ 68
 http_req_receiving.............: avg=78.76µs  min=36µs     med=57.5µs   max=440µs   p(90)=126.9µs  p(95)=164.69µs
 http_req_sending...............: avg=159.45µs min=94µs     med=126µs    max=827µs   p(90)=269.1µs  p(95)=310.29µs
 http_req_tls_handshaking.......: avg=853.38µs min=0s       med=0s       max=30.62ms p(90)=0s       p(95)=0s
 http_req_waiting...............: avg=446.92ms min=283.48ms med=334.41ms max=2.01s   p(90)=678.5ms  p(95)=846.04ms
 http_reqs......................: 68      4.449138/s
 iteration_duration.............: avg=448.76ms min=284.06ms med=334.94ms max=2.01s   p(90)=691.53ms p(95)=846.38ms
 iterations.....................: 68      4.449138/s
 vus............................: 2       min=2      max=2
 vus_max........................: 2       min=2      max=2
```

- Performance test with querying masterdata to get the feature flag:

```
checks.........................: 100.00% ✓ 55       ✗ 0
 data_received..................: 87 kB   5.7 kB/s
 data_sent......................: 227 kB  15 kB/s
 http_req_blocked...............: avg=6.07ms   min=0s       med=1µs      max=167.95ms p(90)=1µs      p(95)=1µs
 http_req_connecting............: avg=300.87µs min=0s       med=0s       max=8.4ms    p(90)=0s       p(95)=0s
 http_req_duration..............: avg=542.62ms min=359.82ms med=424.6ms  max=2.16s    p(90)=793.51ms p(95)=1.03s
   { expected_response:true }...: avg=542.62ms min=359.82ms med=424.6ms  max=2.16s    p(90)=793.51ms p(95)=1.03s
 http_req_failed................: 0.00%   ✓ 0        ✗ 55
 http_req_receiving.............: avg=67.05µs  min=47µs     med=60µs     max=156µs    p(90)=90.6µs   p(95)=101.09µs
 http_req_sending...............: avg=165.09µs min=97µs     med=128µs    max=1.36ms   p(90)=195.2µs  p(95)=264.49µs
 http_req_tls_handshaking.......: avg=1.01ms   min=0s       med=0s       max=29.21ms  p(90)=0s       p(95)=0s
 http_req_waiting...............: avg=542.39ms min=359.55ms med=424.38ms max=2.16s    p(90)=793.3ms  p(95)=1.03s
 http_reqs......................: 55      3.633857/s
 iteration_duration.............: avg=548.92ms min=360.1ms  med=424.77ms max=2.32s    p(90)=808.77ms p(95)=1.06s
 iterations.....................: 55      3.633857/s
 vus............................: 2       min=2      max=2
 vus_max........................: 2       min=2      max=2
```

[Workspace](https://tokenvalidation--b2bsuite.myvtex.com)
