### PR TITLE
feat: add createUserWithEmail graphql API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add createUser graphql API
+
 ## [0.44.1] - 2023-11-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add createUserWithEmail graphql API
+- Add new createUserWithEmail graphql API for bulk import use case
 
 ## [0.45.0] - 2023-11-28
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -203,6 +203,16 @@ type Mutation {
     @withPermissions
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
+  createUser(
+    orgId: ID!
+    costId: ID!
+    roleId: ID!
+    name: String!
+    email: String!
+    canImpersonate: Boolean = false
+  ): MutationResponse
+    @checkAdminAccess
+    @cacheControl(scope: PRIVATE)
   updateUser(
     id: ID
     roleId: ID!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -188,6 +188,13 @@ type Mutation {
     @withPermissions
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
+  """
+    addUser will create an user with the provided parameters.
+    This is called either from the Admin UI or the storefront UI (where
+    the buyer org manager/admin can add a new member to its own org/cost center).
+    Although the mutation allows an id/userId/clId to be provided, these are not
+    exposed/collected on the UIs.
+  """
   addUser(
     id: ID
     roleId: ID!
@@ -203,7 +210,18 @@ type Mutation {
     @withPermissions
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
-  createUser(
+  """
+    createUserWithEmail is a simplified version of addUser. Both
+    mutations will create an user for the org/cost center,
+    but createUserWithEmail expect all fields (except canImpersonate) as
+    required and does not allow the user to provide its own id/userId/clId,
+    which will be automatically created by the mutation. In this case, the
+    email is clearly used as an identifier for the user. This is currently
+    used by the bulk import use case, but could be used by other use cases
+    as well. This function also has stricter permissions to be used by the
+    store admin only, but could have less strict permissions in the future.
+  """
+  createUserWithEmail(
     orgId: ID!
     costId: ID!
     roleId: ID!

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -520,12 +520,16 @@ const Users = {
     } = ctx as any
 
     try {
-      const result = await storefrontPermissionsClient
-        .addUser({ orgId, costId, roleId, name, email, canImpersonate })
-
+      const result = await storefrontPermissionsClient.addUser({
+        orgId,
+        costId,
+        roleId,
+        name,
+        email,
+        canImpersonate,
+      })
       return result.data.addUser
-
-    } catch (error: any) {
+    } catch (error) {
       logger.error({
         error,
         message: 'addUser-error',

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -509,7 +509,7 @@ const Users = {
       })
   },
 
-  createUser: async (
+  createUserWithEmail: async (
     _: void,
     { orgId, costId, roleId, name, email, canImpersonate }: UserArgs,
     ctx: Context
@@ -519,32 +519,30 @@ const Users = {
       vtex: { logger },
     } = ctx as any
 
-    return storefrontPermissionsClient
-      .addUser({ orgId, costId, roleId, name, email, canImpersonate })
-      .then((result: any) => {
-        return result.data.addUser
+    try {
+      const result = await storefrontPermissionsClient
+        .addUser({ orgId, costId, roleId, name, email, canImpersonate })
+
+      return result.data.addUser
+
+    } catch (error: any) {
+      logger.error({
+        error,
+        message: 'addUser-error',
       })
-      .catch((error: any) => {
-        logger.error({
-          error,
-          message: 'addUser-error',
-        })
-
-        const message = error.graphQLErrors[0]?.message ?? error.message
-        let status = ''
-
-        if (message.includes(MessageSFPUserAddError.DUPLICATED)) {
-          status = StatusAddUserError.DUPLICATED
-        } else if (
-          message.includes(MessageSFPUserAddError.DUPLICATED_ORGANIZATION)
-        ) {
-          status = StatusAddUserError.DUPLICATED_ORGANIZATION
-        } else {
-          status = StatusAddUserError.ERROR
-        }
-
-        return { status, message }
-      })
+      const message = error.graphQLErrors[0]?.message ?? error.message
+      let status = ''
+      if (message.includes(MessageSFPUserAddError.DUPLICATED)) {
+        status = StatusAddUserError.DUPLICATED
+      } else if (
+        message.includes(MessageSFPUserAddError.DUPLICATED_ORGANIZATION)
+      ) {
+        status = StatusAddUserError.DUPLICATED_ORGANIZATION
+      } else {
+        status = StatusAddUserError.ERROR
+      }
+      return { status, message }
+    }
   },
 
   updateUser: async (

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -532,7 +532,7 @@ const Users = {
     } catch (error) {
       logger.error({
         error,
-        message: 'addUser-error',
+        message: 'createUserWithEmail-error',
       })
       const message = error.graphQLErrors?.[0]?.message ?? error.message
       let status = ''

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -534,7 +534,7 @@ const Users = {
         error,
         message: 'addUser-error',
       })
-      const message = error.graphQLErrors[0]?.message ?? error.message
+      const message = error.graphQLErrors?.[0]?.message ?? error.message
       let status = ''
       if (message.includes(MessageSFPUserAddError.DUPLICATED)) {
         status = StatusAddUserError.DUPLICATED


### PR DESCRIPTION
#### What problem is this solving?

Add a `createUserWithEmail` graphql with @checkAdminAccess directive to be called by the b2b-bulk-import app. This `createUserWithEmail` has stricter params than `addUser` and ultimately calls the storefront permissions addUser (just as the `addUser` graphql api).
This is also to avoid touching on the permissions of `addUser` that uses the @checkUserAccess directive.

#### How to test it?

Try to create an user calling the `createUserWithEmail` API providing the expected parameters (note only `canImpersonate` is optional):
```
  createUser(
    orgId: ID!
    costId: ID!
    roleId: ID!
    name: String!
    email: String!
    canImpersonate: Boolean = false
  )
```
