### PR TITLE
feat: add token validation and token to call storefront-permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add token validation in graphql operations and token to call storefront-permission
+
 ## [0.46.0] - 2023-11-28
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -25,7 +25,8 @@ type Query {
     @cacheControl(scope: PRIVATE)
 
   getOrganizationById(id: ID): Organization
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -56,7 +57,8 @@ type Query {
     sortedBy: String = "name"
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
@@ -94,8 +96,11 @@ type Query {
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getMarketingTags(costId: ID!): MarketingTags
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
-  getB2BSettings: B2BSettings @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
+  getB2BSettings: B2BSettings
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 
@@ -104,7 +109,7 @@ type Mutation {
   createOrganizationRequest(
     input: OrganizationInput!
     notifyUsers: Boolean
-  ): MasterDataResponse @checkUserAccess
+  ): MasterDataResponse
   updateOrganizationRequest(
     id: ID!
     status: String!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -25,8 +25,8 @@ type Query {
     @cacheControl(scope: PRIVATE)
 
   getOrganizationById(id: ID): Organization
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE)
+    @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -57,8 +57,8 @@ type Query {
     sortedBy: String = "name"
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
@@ -80,8 +80,8 @@ type Query {
     @checkUserAccess
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getPaymentTerms: [PaymentTerm]
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
 
   getOrganizationsByEmail(email: String): [B2BOrganization]
     @checkUserAccess
@@ -89,12 +89,12 @@ type Query {
 
   checkOrganizationIsActive(id: String): Boolean @cacheControl(scope: PRIVATE)
   getSalesChannels: [Channels]
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
   getBinding(email: String!): Boolean
     @withSession
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @auditAccess
   getMarketingTags(costId: ID!): MarketingTags
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
@@ -265,7 +265,6 @@ type Mutation {
     @withSession
     @withPermissions
     @cacheControl(scope: PRIVATE)
-    @checkUserAccess
   saveSalesChannels(channels: [SalesChannelsInput]!): MutationResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -18,14 +18,14 @@ type Query {
     sortOrder: String = "ASC"
     sortedBy: String = "name"
   ): OrganizationResult
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
 
   getOrganizationById(id: ID): Organization
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
@@ -46,7 +46,7 @@ type Query {
     sortOrder: String = "ASC"
     sortedBy: String = "name"
   ): CostCenterResult
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getCostCentersByOrganizationIdStorefront(
     id: ID
@@ -57,7 +57,7 @@ type Query {
     sortedBy: String = "name"
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
@@ -80,7 +80,7 @@ type Query {
     @checkUserAccess
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getPaymentTerms: [PaymentTerm]
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
 
   getOrganizationsByEmail(email: String): [B2BOrganization]
@@ -89,17 +89,17 @@ type Query {
 
   checkOrganizationIsActive(id: String): Boolean @cacheControl(scope: PRIVATE)
   getSalesChannels: [Channels]
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getBinding(email: String!): Boolean
     @withSession
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getMarketingTags(costId: ID!): MarketingTags
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getB2BSettings: B2BSettings
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,18 +17,20 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): OrganizationResult @cacheControl(scope: PUBLIC, maxAge: SHORT) @auditAccess
+  ): OrganizationResult
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @checkUserAccess
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
 
   getOrganizationById(id: ID): Organization
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
-    @auditAccess
+    @checkUserAccess
   getCostCenters(
     search: String
     page: Int = 1
@@ -43,7 +45,9 @@ type Query {
     pageSize: Int = 25
     sortOrder: String = "ASC"
     sortedBy: String = "name"
-  ): CostCenterResult @cacheControl(scope: PUBLIC, maxAge: SHORT) @auditAccess
+  ): CostCenterResult
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @checkUserAccess
   getCostCentersByOrganizationIdStorefront(
     id: ID
     search: String
@@ -54,11 +58,11 @@ type Query {
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getUsers(organizationId: ID, costCenterId: ID): [B2BUser]
     @withSession
     @checkUserAccess
@@ -77,27 +81,26 @@ type Query {
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getPaymentTerms: [PaymentTerm]
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
 
   getOrganizationsByEmail(email: String): [B2BOrganization]
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
-    @auditAccess
 
   checkOrganizationIsActive(id: String): Boolean @cacheControl(scope: PRIVATE)
   getSalesChannels: [Channels]
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getBinding(email: String!): Boolean
     @withSession
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getMarketingTags(costId: ID!): MarketingTags
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getB2BSettings: B2BSettings
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @checkUserAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 
@@ -106,7 +109,7 @@ type Mutation {
   createOrganizationRequest(
     input: OrganizationInput!
     notifyUsers: Boolean
-  ): MasterDataResponse @auditAccess
+  ): MasterDataResponse @checkUserAccess
   updateOrganizationRequest(
     id: ID!
     status: String!
@@ -134,9 +137,7 @@ type Mutation {
   createCostCenterWithId(
     organizationId: ID
     input: CostCenterInput!
-  ): MasterDataResponse
-    @checkAdminAccess
-    @cacheControl(scope: PRIVATE)
+  ): MasterDataResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
   updateOrganization(
     id: ID!
     name: String!
@@ -195,11 +196,11 @@ type Mutation {
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
   """
-    addUser will create an user with the provided parameters.
-    This is called either from the Admin UI or the storefront UI (where
-    the buyer org manager/admin can add a new member to its own org/cost center).
-    Although the mutation allows an id/userId/clId to be provided, these are not
-    exposed/collected on the UIs.
+  addUser will create an user with the provided parameters.
+  This is called either from the Admin UI or the storefront UI (where
+  the buyer org manager/admin can add a new member to its own org/cost center).
+  Although the mutation allows an id/userId/clId to be provided, these are not
+  exposed/collected on the UIs.
   """
   addUser(
     id: ID
@@ -217,15 +218,15 @@ type Mutation {
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
   """
-    createUserWithEmail is a simplified version of addUser. Both
-    mutations will create an user for the org/cost center,
-    but createUserWithEmail expect all fields (except canImpersonate) as
-    required and does not allow the user to provide its own id/userId/clId,
-    which will be automatically created by the mutation. In this case, the
-    email is clearly used as an identifier for the user. This is currently
-    used by the bulk import use case, but could be used by other use cases
-    as well. This function also has stricter permissions to be used by the
-    store admin only, but could have less strict permissions in the future.
+  createUserWithEmail is a simplified version of addUser. Both
+  mutations will create an user for the org/cost center,
+  but createUserWithEmail expect all fields (except canImpersonate) as
+  required and does not allow the user to provide its own id/userId/clId,
+  which will be automatically created by the mutation. In this case, the
+  email is clearly used as an identifier for the user. This is currently
+  used by the bulk import use case, but could be used by other use cases
+  as well. This function also has stricter permissions to be used by the
+  store admin only, but could have less strict permissions in the future.
   """
   createUserWithEmail(
     orgId: ID!
@@ -234,9 +235,7 @@ type Mutation {
     name: String!
     email: String!
     canImpersonate: Boolean = false
-  ): MutationResponse
-    @checkAdminAccess
-    @cacheControl(scope: PRIVATE)
+  ): MutationResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
   updateUser(
     id: ID
     roleId: ID!
@@ -266,6 +265,7 @@ type Mutation {
     @withSession
     @withPermissions
     @cacheControl(scope: PRIVATE)
+    @checkUserAccess
   saveSalesChannels(channels: [SalesChannelsInput]!): MutationResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -26,7 +26,6 @@ type Query {
 
   getOrganizationById(id: ID): Organization
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -58,7 +57,6 @@ type Query {
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
@@ -97,10 +95,7 @@ type Query {
     @checkUserAccess
   getMarketingTags(costId: ID!): MarketingTags
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
-  getB2BSettings: B2BSettings
-    @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
+  getB2BSettings: B2BSettings @cacheControl(scope: PRIVATE, maxAge: SHORT)
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -24,9 +24,7 @@ type Query {
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
 
-  getOrganizationById(id: ID): Organization
-    @cacheControl(scope: PRIVATE)
-    @checkUserAccess
+  getOrganizationById(id: ID): Organization @cacheControl(scope: PRIVATE)
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -58,7 +56,6 @@ type Query {
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -167,7 +167,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
       }
     )
   }
@@ -207,7 +207,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
       }
     )
   }
@@ -248,7 +248,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
       }
     )
   }
@@ -272,7 +272,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
       }
     )
   }
@@ -290,7 +290,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
         params: {
           locale: this.context.locale,
         },
@@ -300,11 +300,19 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     return graphqlResult
   }
 
-  private getTokenToHeader = (ctx: IOContext) => {
+  private getTokenToHeader = () => {
+    const token =
+      this.context.storeUserAuthToken ??
+      this.context.adminUserAuthToken ??
+      this.context.authToken
+
+    const { sessionToken } = this.context
+
     return {
-      VtexIdclientAutCookie:
-        ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
-      cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
+      'x-vtex-credential': this.context.authToken,
+      VtexIdclientAutCookie: token,
+      cookie: `VtexIdclientAutCookie=${token}`,
+      'x-vtex-session': sessionToken,
     }
   }
 
@@ -333,7 +341,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         variables,
       },
       {
-        headers: this.getTokenToHeader(this.context),
+        headers: this.getTokenToHeader(),
         params: {
           locale: this.context.locale,
         },

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -119,16 +119,11 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }
 
   public getUser = async (userId: string): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: this.getPersistedQuery(),
-        query: getUser,
-        variables: { id: userId },
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getUser,
+      variables: { id: userId },
+    })
   }
 
   public getB2BUser = async (id: string): Promise<any> => {
@@ -309,6 +304,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     return {
       VtexIdclientAutCookie:
         ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
+      cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
     }
   }
 

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -21,9 +21,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     super('vtex.storefront-permissions@1.x', ctx, options)
   }
 
-  public checkUserPermission = async (): Promise<any> => {
+  public checkUserPermission = async (app?: string): Promise<any> => {
     return this.query({
-      extensions: this.getPersistedQuery(),
+      extensions: this.getPersistedQuery(app),
       query: getPermission,
       variables: {},
     })
@@ -312,11 +312,13 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     }
   }
 
-  private getPersistedQuery = () => {
+  private getPersistedQuery = (
+    sender = 'vtex.b2b-organizations-graphql@0.x'
+  ) => {
     return {
       persistedQuery: {
         provider: 'vtex.storefront-permissions@1.x',
-        sender: 'vtex.b2b-organizations-graphql@0.x',
+        sender,
       },
     }
   }

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -6,118 +6,61 @@ import deleteUser from '../mutations/deleteUser'
 import impersonateUser from '../mutations/impersonateUser'
 import saveUser from '../mutations/saveUser'
 import updateUser from '../mutations/updateUser'
+import getB2BUser from '../queries/getB2BUser'
+import getOrganizationsByEmail from '../queries/getOrganizationsByEmail'
 import getPermission from '../queries/getPermission'
 import getRole from '../queries/getRole'
 import getUser from '../queries/getUser'
-import getB2BUser from '../queries/getB2BUser'
 import listAllUsers from '../queries/listAllUsers'
 import listRoles from '../queries/listRoles'
 import listUsers from '../queries/listUsers'
 import listUsersPaginated from '../queries/listUsersPaginated'
-import getOrganizationsByEmail from '../queries/getOrganizationsByEmail'
 
 export default class StorefrontPermissions extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super('vtex.storefront-permissions@1.x', ctx, options)
   }
 
-  private getTokenToHeader = (ctx: IOContext) => {
-    return {
-      VtexIdclientAutCookie:
-        ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
-    }
-  }
-
   public checkUserPermission = async (): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: getPermission,
-        variables: {},
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getPermission,
+      variables: {},
+    })
   }
 
   public getOrganizationsByEmail = async (email: string): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: getOrganizationsByEmail,
-        variables: {
-          email,
-        },
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getOrganizationsByEmail,
+      variables: {
+        email,
       },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    })
   }
 
   public listRoles = async (): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: listRoles,
-        variables: {},
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: listRoles,
+      variables: {},
+    })
   }
 
   public getRole = async (roleId: string): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: getRole,
-        variables: { id: roleId },
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getRole,
+      variables: { id: roleId },
+    })
   }
 
   public listAllUsers = async (): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: listAllUsers,
-        variables: {},
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: listAllUsers,
+      variables: {},
+    })
   }
 
   public listUsers = async ({
@@ -129,25 +72,15 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     organizationId?: string
     costCenterId?: string
   }): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: listUsers,
-        variables: {
-          roleId,
-          ...(organizationId && { organizationId }),
-          ...(costCenterId && { costCenterId }),
-        },
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: listUsers,
+      variables: {
+        roleId,
+        ...(organizationId && { organizationId }),
+        ...(costCenterId && { costCenterId }),
       },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    })
   }
 
   public listUsersPaginated = async ({
@@ -169,41 +102,26 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     sortOrder?: string
     sortedBy?: string
   }): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: listUsersPaginated,
-        variables: {
-          page,
-          pageSize,
-          roleId,
-          search,
-          sortOrder,
-          sortedBy,
-          ...(organizationId && { organizationId }),
-          ...(costCenterId && { costCenterId }),
-        },
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: listUsersPaginated,
+      variables: {
+        page,
+        pageSize,
+        roleId,
+        search,
+        sortOrder,
+        sortedBy,
+        ...(organizationId && { organizationId }),
+        ...(costCenterId && { costCenterId }),
       },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    })
   }
 
   public getUser = async (userId: string): Promise<any> => {
     return this.graphql.query(
       {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
+        extensions: this.getPersistedQuery(),
         query: getUser,
         variables: { id: userId },
       },
@@ -214,21 +132,11 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }
 
   public getB2BUser = async (id: string): Promise<any> => {
-    return this.graphql.query(
-      {
-        extensions: {
-          persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations-graphql@0.x',
-          },
-        },
-        query: getB2BUser,
-        variables: { id },
-      },
-      {
-        headers: this.getTokenToHeader(this.context),
-      }
-    )
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getB2BUser,
+      variables: { id },
+    })
   }
 
   public addUser = async ({
@@ -395,5 +303,43 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     )
 
     return graphqlResult
+  }
+
+  private getTokenToHeader = (ctx: IOContext) => {
+    return {
+      VtexIdclientAutCookie:
+        ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
+    }
+  }
+
+  private getPersistedQuery = () => {
+    return {
+      persistedQuery: {
+        provider: 'vtex.storefront-permissions@1.x',
+        sender: 'vtex.b2b-organizations-graphql@0.x',
+      },
+    }
+  }
+
+  private query = async (param: {
+    query: string
+    variables: any
+    extensions: any
+  }): Promise<any> => {
+    const { query, variables, extensions } = param
+
+    return this.graphql.query(
+      {
+        extensions,
+        query,
+        variables,
+      },
+      {
+        headers: this.getTokenToHeader(this.context),
+        params: {
+          locale: this.context.locale,
+        },
+      }
+    )
   }
 }

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -6,7 +6,6 @@ import deleteUser from '../mutations/deleteUser'
 import impersonateUser from '../mutations/impersonateUser'
 import saveUser from '../mutations/saveUser'
 import updateUser from '../mutations/updateUser'
-import checkImpersonation from '../queries/checkImpersonation'
 import getPermission from '../queries/getPermission'
 import getRole from '../queries/getRole'
 import getUser from '../queries/getUser'
@@ -22,35 +21,48 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     super('vtex.storefront-permissions@1.x', ctx, options)
   }
 
-  public checkUserPermission = async (app?: string): Promise<any> => {
+  private getTokenToHeader = (ctx: IOContext) => {
+    return {
+      VtexIdclientAutCookie: ctx.storeUserAuthToken ?? ctx.adminUserAuthToken,
+    }
+  }
+
+  public checkUserPermission = async (): Promise<any> => {
     return this.graphql.query(
       {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: app ?? 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: getPermission,
         variables: {},
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
   public getOrganizationsByEmail = async (email: string): Promise<any> => {
-    return this.graphql.query({
-      extensions: {
-        persistedQuery: {
-          provider: 'vtex.storefront-permissions@1.x',
-          sender: 'vtex.b2b-organizations@0.x',
+    return this.graphql.query(
+      {
+        extensions: {
+          persistedQuery: {
+            provider: 'vtex.storefront-permissions@1.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
+          },
+        },
+        query: getOrganizationsByEmail,
+        variables: {
+          email,
         },
       },
-      query: getOrganizationsByEmail,
-      variables: {
-        email,
-      },
-    })
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
+    )
   }
 
   public listRoles = async (): Promise<any> => {
@@ -59,13 +71,15 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: listRoles,
         variables: {},
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
@@ -75,13 +89,15 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: getRole,
         variables: { id: roleId },
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
@@ -91,13 +107,15 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: listAllUsers,
         variables: {},
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
@@ -115,7 +133,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: listUsers,
@@ -125,7 +143,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           ...(costCenterId && { costCenterId }),
         },
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
@@ -153,7 +173,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
         query: listUsersPaginated,
@@ -168,49 +188,45 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           ...(costCenterId && { costCenterId }),
         },
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
   public getUser = async (userId: string): Promise<any> => {
-    return this.graphql.query({
-      extensions: {
-        persistedQuery: {
-          provider: 'vtex.storefront-permissions@1.x',
-          sender: 'vtex.b2b-organizations@0.x',
-        },
-      },
-      query: getUser,
-      variables: { id: userId },
-    })
-  }
-
-  public getB2BUser = async (id: string): Promise<any> => {
-    return this.graphql.query({
-      extensions: {
-        persistedQuery: {
-          provider: 'vtex.storefront-permissions@1.x',
-          sender: 'vtex.b2b-organizations@0.x',
-        },
-      },
-      query: getB2BUser,
-      variables: { id },
-    })
-  }
-
-  public checkImpersonation = async (): Promise<any> => {
     return this.graphql.query(
       {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
           },
         },
-        query: checkImpersonation,
-        variables: {},
+        query: getUser,
+        variables: { id: userId },
       },
-      {}
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
+    )
+  }
+
+  public getB2BUser = async (id: string): Promise<any> => {
+    return this.graphql.query(
+      {
+        extensions: {
+          persistedQuery: {
+            provider: 'vtex.storefront-permissions@1.x',
+            sender: 'vtex.b2b-organizations-graphql@0.x',
+          },
+        },
+        query: getB2BUser,
+        variables: { id },
+      },
+      {
+        headers: this.getTokenToHeader(this.context),
+      }
     )
   }
 
@@ -247,11 +263,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: {
-          ...(this.context.authToken && {
-            cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
-          }),
-        },
+        headers: this.getTokenToHeader(this.context),
       }
     )
   }
@@ -291,11 +303,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: {
-          ...(this.context.authToken && {
-            cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
-          }),
-        },
+        headers: this.getTokenToHeader(this.context),
       }
     )
   }
@@ -336,11 +344,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: {
-          ...(this.context.authToken && {
-            cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
-          }),
-        },
+        headers: this.getTokenToHeader(this.context),
       }
     )
   }
@@ -364,11 +368,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: {
-          ...(this.context.authToken && {
-            cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
-          }),
-        },
+        headers: this.getTokenToHeader(this.context),
       }
     )
   }
@@ -386,14 +386,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         },
       },
       {
-        headers: {
-          ...(this.context.sessionToken && {
-            sessionToken: this.context.sessionToken,
-          }),
-          ...(this.context.authToken && {
-            cookie: `VtexIdclientAutCookie=${this.context.authToken}`,
-          }),
-        },
+        headers: this.getTokenToHeader(this.context),
         params: {
           locale: this.context.locale,
         },

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -23,7 +23,8 @@ export default class StorefrontPermissions extends AppGraphQLClient {
 
   private getTokenToHeader = (ctx: IOContext) => {
     return {
-      VtexIdclientAutCookie: ctx.storeUserAuthToken ?? ctx.adminUserAuthToken,
+      VtexIdclientAutCookie:
+        ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
     }
   }
 

--- a/node/resolvers/Queries/MarketingTags.ts
+++ b/node/resolvers/Queries/MarketingTags.ts
@@ -16,7 +16,7 @@ const MarketingTags = {
     } catch (error) {
       logger.error({
         error,
-        message: 'setMarketingTags.error',
+        message: 'getMarketingTags.error',
       })
 
       return { status: 'error', message: error }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -38,7 +38,7 @@ const getUserAndPermissions = async (ctx: Context) => {
   const {
     data: { checkUserPermission },
   }: any = await storefrontPermissions
-    // I don't know why this name sender is necessary, maybe it is some policy or permission.
+    // It is necessary to send the app name, because the check user return the permissions relative to orders-history to access the page.
     .checkUserPermission('vtex.b2b-orders-history@0.x')
     .catch((error: any) => {
       logger.error({

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -1,4 +1,4 @@
-import { UserInputError, ForbiddenError } from '@vtex/api'
+import { ForbiddenError, UserInputError } from '@vtex/api'
 
 import {
   COST_CENTER_DATA_ENTITY,
@@ -38,7 +38,7 @@ const getUserAndPermissions = async (ctx: Context) => {
   const {
     data: { checkUserPermission },
   }: any = await storefrontPermissions
-    .checkUserPermission('vtex.b2b-orders-history@0.x')
+    .checkUserPermission()
     .catch((error: any) => {
       logger.error({
         message: 'checkUserPermission-error',

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -38,7 +38,8 @@ const getUserAndPermissions = async (ctx: Context) => {
   const {
     data: { checkUserPermission },
   }: any = await storefrontPermissions
-    .checkUserPermission()
+    // I don't know why this name sender is necessary, maybe it is some policy or permission.
+    .checkUserPermission('vtex.b2b-orders-history@0.x')
     .catch((error: any) => {
       logger.error({
         message: 'checkUserPermission-error',

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -14,7 +14,7 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
       info: any
     ) => {
       const {
-        vtex: { adminUserAuthToken, storeUserAuthToken, authToken, logger },
+        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
         clients: { identity, vtexId },
       } = context
 
@@ -31,7 +31,7 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         context.vtex.adminUserAuthToken = token
       }
 
-      if (!token && !storeUserAuthToken && !authToken) {
+      if (!token && !storeUserAuthToken) {
         throw new AuthenticationError('No admin or store token was provided')
       }
 
@@ -64,17 +64,6 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         }
 
         if (!authUser) {
-          throw new ForbiddenError('Unauthorized Access')
-        }
-      } else if (authToken) {
-        try {
-          await identity.validateToken({ token: authToken })
-        } catch (err) {
-          logger.warn({
-            error: err,
-            message: 'CheckUserAccess: Invalid auth token',
-            token,
-          })
           throw new ForbiddenError('Unauthorized Access')
         }
       }


### PR DESCRIPTION
#### What problem is this solving?

We found some apps that don't pass the token to call graphql queries or mutations. So we need a guarantee to have all integrations send the token, and we will block unauthenticated requests from the app provider.

#### How to test it?

- Open the [page organizations](https://b2bteam1285--b2bstore005.myvtex.com/admin/b2b-organizations/organizations#/organizations) in the admin. `test getOrganizations`
- Select [one organization](https://b2bteam1285--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/d9e51195-0c39-11ed-835d-0ac601682b29/#/default) from page organizations. `test getOrganizationById`
- Open the [page My quotes](https://b2bteam1285--b2bstore005.myvtex.com/b2b-quotes). `test getOrganizationByIdStorefront and getOrganizationsByEmail`
- In the page My quotes, filter the quotes by cost center. `test getCostCentersByOrganizationId`
- Open the page organizations in the admin, select an organization and open the [tab payment terms](https://b2bteam1285--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/d9e51195-0c39-11ed-835d-0ac601682b29/#/pay-terms). `test getPaymentTerms`
- Open the page organizations in the admin, select an organization and open the [tab sales channel](https://b2bteam1285--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/d9e51195-0c39-11ed-835d-0ac601682b29/#/sales-channel). `test getSalesChannels`


[Workspace](https://b2bteam1285--b2bstore005.myvtex.com/)