### PR TITLE
feat: add token validation for storefront permissions dependencies

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -25,8 +25,8 @@ type Query {
     @cacheControl(scope: PRIVATE)
 
   getOrganizationById(id: ID): Organization
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -57,8 +57,8 @@ type Query {
     sortedBy: String = "name"
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
@@ -96,11 +96,11 @@ type Query {
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @checkUserAccess
   getMarketingTags(costId: ID!): MarketingTags
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getB2BSettings: B2BSettings
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
-    @auditAccess
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 


### PR DESCRIPTION
#### What problem is this solving?

We found some apps that don't pass the token to call graphql queries or mutations. So we need a guarantee to have all integrations send the token, and we will block unauthenticated requests from the app provider.

For the b2b-organization we needed to split the changes into two PRs, one to send token in each storefront-permission integration and validate token for operations that storefront-permissions do not use, and another to put the token validation for operations used by storefront-permissions.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://security--b2bsuite.myvtex.com/)

#### Related to / Depends on

This PR depends on [PR-140](https://github.com/vtex-apps/b2b-organizations-graphql/pull/140)
