### PR TITLE
fix: check the session token to set as header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Validate if the session token is not undefined to set as headers to call storefront-permissions
+
 ## [0.47.0] - 2023-12-14
 
 ### Added

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -312,7 +312,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       'x-vtex-credential': this.context.authToken,
       VtexIdclientAutCookie: token,
       cookie: `VtexIdclientAutCookie=${token}`,
-      'x-vtex-session': sessionToken,
+      ...(sessionToken && {
+        'x-vtex-session': sessionToken,
+      }), // The axios client http doesn't allow undefined headers
     }
   }
 


### PR DESCRIPTION
#### What problem is this solving?

When it calls storefront-permission without a session token the axios http client throws an error because it doesn't accept undefined headers.

```
{"code":"ERR_HTTP_INVALID_HEADER_VALUE","name":"TypeError","message":"Invalid value \"undefined\" for header \"x-vtex-session\"","stack":"TypeError: Invalid value \"undefined\" for header \"x-vtex-session\"\n    at ClientRequest.setHeader (node:_http_outgoing:647:3)\n    at new ClientRequest (node:_http_client:284:14)\n    at Object.request (node:http:97:10)\n    at dispatchHttpRequest (/usr/local/data/service/node_modules/axios/lib/adapters/http.js:202:25)\n    at new Promise (<anonymous>)\n    at httpAdapter (/usr/local/data/service/node_modules/axios/lib/adapters/http.js:46:10)\n    at dispatchRequest (/usr/local/data/service/node_modules/axios/lib/core/dispatchRequest.js:53:10)\n
```

#### How to test it?

- Call some operations without set `vtex-session`.

[Workspace](https://security--b2bsuite.myvtex.com/)

