### PR TITLE
Add IsCorporate in AddUser and UpdateUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `isCorporate`, `tradeAccount`, `corporateName` and `corporateDocument` in `addUser` and `updateUser`
+
 ## [0.48.0] - 2024-01-19
 
 ### Added

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -144,7 +144,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     email,
     corporateName,
     corporateDocument,
-    tradeName
+    tradeName,
   }: {
     id?: string
     roleId: string
@@ -173,7 +173,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           userId,
           corporateName,
           corporateDocument,
-          tradeName
+          tradeName,
         },
       },
       {
@@ -193,7 +193,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     email,
     corporateName,
     corporateDocument,
-    tradeName
+    tradeName,
   }: {
     id?: string
     roleId: string
@@ -223,7 +223,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           userId,
           corporateName,
           corporateDocument,
-          tradeName
+          tradeName,
         },
       },
       {

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -142,6 +142,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     costId,
     name,
     email,
+    corporateName,
+    corporateDocument,
+    tradeName
   }: {
     id?: string
     roleId: string
@@ -151,12 +154,16 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     clId?: string
     name: string
     email: string
+    corporateName: string
+    corporateDocument: string
+    tradeName: string
   }): Promise<any> => {
     return this.graphql.mutate(
       {
         mutate: addUser,
         variables: {
           canImpersonate: false,
+          isCorporate: true,
           costId,
           email,
           id,
@@ -164,6 +171,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           orgId,
           roleId,
           userId,
+          corporateName,
+          corporateDocument,
+          tradeName
         },
       },
       {
@@ -181,6 +191,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     clId,
     name,
     email,
+    corporateName,
+    corporateDocument,
+    tradeName
   }: {
     id?: string
     roleId: string
@@ -190,12 +203,16 @@ export default class StorefrontPermissions extends AppGraphQLClient {
     clId?: string
     name: string
     email: string
+    corporateName: string
+    corporateDocument: string
+    tradeName: string
   }): Promise<any> => {
     return this.graphql.mutate(
       {
         mutate: updateUser,
         variables: {
           canImpersonate: false,
+          isCorporate: true,
           clId,
           costId,
           email,
@@ -204,6 +221,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
           orgId,
           roleId,
           userId,
+          corporateName,
+          corporateDocument,
+          tradeName
         },
       },
       {

--- a/node/mutations/addUser.ts
+++ b/node/mutations/addUser.ts
@@ -8,9 +8,13 @@ export default print(gql`
     $roleId: ID!
     $orgId: ID!
     $costId: ID!
-    $name: String!
     $canImpersonate: Boolean!
+    $name: String!
     $email: String!
+    $isCorporate: Boolean
+    $corporateName: String
+    $corporateDocument: String
+    $tradeName: String
   ) {
     addUser(
       id: $id
@@ -18,9 +22,13 @@ export default print(gql`
       roleId: $roleId
       orgId: $orgId
       costId: $costId
-      name: $name
       canImpersonate: $canImpersonate
+      name: $name
       email: $email
+      isCorporate: $isCorporate
+      corporateName: $corporateName
+      corporateDocument: $corporateDocument
+      tradeName: $tradeName
     ) {
       id
       status

--- a/node/mutations/updateUser.ts
+++ b/node/mutations/updateUser.ts
@@ -12,6 +12,10 @@ export default print(gql`
     $canImpersonate: Boolean!
     $name: String
     $email: String
+    $isCorporate: Boolean!
+    $corporateName: String
+    $corporateDocument: String
+    $tradeName: String
   ) {
     updateUser(
       id: $id
@@ -23,6 +27,10 @@ export default print(gql`
       canImpersonate: $canImpersonate
       name: $name
       email: $email
+      isCorporate: $isCorporate
+      corporateName: $corporateName
+      corporateDocument: $corporateDocument
+      tradeName: $tradeName
     ) {
       id
       status

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -1,5 +1,8 @@
 import { MessageSFPUserAddError, StatusAddUserError } from '../../constants'
-import { COST_CENTER_DATA_ENTITY, ORGANIZATION_DATA_ENTITY} from '../../mdSchema'
+import {
+  COST_CENTER_DATA_ENTITY,
+  ORGANIZATION_DATA_ENTITY,
+} from '../../mdSchema'
 import GraphQLError from '../../utils/GraphQLError'
 import type { ImpersonateMetricParams } from '../../utils/metrics/impersonate'
 import {
@@ -79,42 +82,41 @@ const getRoleSlug = async ({
           return ''
         })
 
-const getCostCenterDocument = async ( {masterdata, logger, costId} : any) => {
-  return await masterdata
+const getCostCenterDocument = async ( { masterdata, logger, costId } : any) => {
+  return masterdata
     .getDocument({
       dataEntity : COST_CENTER_DATA_ENTITY,
       fields: ['businessDocument'],
-      id: costId
+      id: costId,
     })
     .then((res: any) => {
       return res?.businessDocument ?? undefined
     })
-    .catch(( error : any) => {
+    .catch((error : any) => {
       logger.error({
         error,
         message: 'getCostCenterDocumentError',
       })
-      return undefined;
+      return undefined
     })
 }
 
-const getOranizationDetails = async ( {masterdata, logger, orgId}: any) => {
-  return await masterdata
+const getOranizationDetails = async ( { masterdata, logger, orgId }: any) => {
+  return masterdata
     .getDocument({
       dataEntity : ORGANIZATION_DATA_ENTITY,
       fields: ['tradeName', 'name'],
-      id: orgId
+      id: orgId,
     })
     .then((res: any) => {
       return res ?? undefined
     })
-    .catch(( error : any) => {
+    .catch((error : any) => {
       logger.error({
         error,
         message: 'getOranizationDetailsError',
       })
-
-      return undefined;
+      return undefined
     })
 }
 
@@ -486,7 +488,10 @@ const Users = {
     ctx: Context
   ) => {
     const {
-      clients: { storefrontPermissions: storefrontPermissionsClient, masterdata },
+      clients: { 
+        storefrontPermissions: storefrontPermissionsClient, 
+        masterdata
+      },
       vtex: { adminUserAuthToken, logger, sessionData, storefrontPermissions },
     } = ctx as any
 
@@ -510,19 +515,19 @@ const Users = {
       throw error
     }
 
-    let tradeName = '';
-    let corporateName = '';
+    let tradeName = ''
+    let corporateName = ''
     
     if (orgId) {
-      let orgDetails = await getOranizationDetails({masterdata, logger, orgId});
-      tradeName = orgDetails?.tradeName;
-      corporateName = orgDetails?.name;
+      const orgDetails = await getOranizationDetails({ masterdata, logger, orgId })
+      tradeName = orgDetails?.tradeName
+      corporateName = orgDetails?.name
     }
 
-    let corporateDocument = '';
+    let corporateDocument = ''
 
     if (costId) {
-      corporateDocument = await getCostCenterDocument({masterdata, logger, costId});
+      corporateDocument = await getCostCenterDocument({ masterdata, logger, costId })
     }
 
     const fields = {
@@ -535,7 +540,7 @@ const Users = {
       userId,
       tradeName,
       corporateName,
-      corporateDocument
+      corporateDocument,
     }
 
     return storefrontPermissionsClient

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -82,17 +82,17 @@ const getRoleSlug = async ({
           return ''
         })
 
-const getCostCenterDocument = async ( { masterdata, logger, costId } : any) => {
+const getCostCenterDocument = async ({ masterdata, logger, costId }: any) => {
   return masterdata
     .getDocument({
-      dataEntity : COST_CENTER_DATA_ENTITY,
+      dataEntity: COST_CENTER_DATA_ENTITY,
       fields: ['businessDocument'],
       id: costId,
     })
     .then((res: any) => {
       return res?.businessDocument ?? undefined
     })
-    .catch((error : any) => {
+    .catch((error: any) => {
       logger.error({
         error,
         message: 'getCostCenterDocumentError',
@@ -101,17 +101,17 @@ const getCostCenterDocument = async ( { masterdata, logger, costId } : any) => {
     })
 }
 
-const getOranizationDetails = async ( { masterdata, logger, orgId }: any) => {
+const getOranizationDetails = async ({ masterdata, logger, orgId }: any) => {
   return masterdata
     .getDocument({
-      dataEntity : ORGANIZATION_DATA_ENTITY,
+      dataEntity: ORGANIZATION_DATA_ENTITY,
       fields: ['tradeName', 'name'],
       id: orgId,
     })
     .then((res: any) => {
       return res ?? undefined
     })
-    .catch((error : any) => {
+    .catch((error: any) => {
       logger.error({
         error,
         message: 'getOranizationDetailsError',
@@ -119,7 +119,6 @@ const getOranizationDetails = async ( { masterdata, logger, orgId }: any) => {
       return undefined
     })
 }
-
 
 const getUser = async ({ masterdata, logger, userId, clId }: any) =>
   (await masterdata
@@ -488,9 +487,9 @@ const Users = {
     ctx: Context
   ) => {
     const {
-      clients: { 
-        storefrontPermissions: storefrontPermissionsClient, 
-        masterdata
+      clients: {
+        storefrontPermissions: storefrontPermissionsClient,
+        masterdata,
       },
       vtex: { adminUserAuthToken, logger, sessionData, storefrontPermissions },
     } = ctx as any
@@ -517,17 +516,23 @@ const Users = {
 
     let tradeName = ''
     let corporateName = ''
-    
     if (orgId) {
-      const orgDetails = await getOranizationDetails({ masterdata, logger, orgId })
+      const orgDetails = await getOranizationDetails({ 
+      masterdata, 
+      logger, 
+      orgId
+    })
       tradeName = orgDetails?.tradeName
       corporateName = orgDetails?.name
     }
 
     let corporateDocument = ''
-
     if (costId) {
-      corporateDocument = await getCostCenterDocument({ masterdata, logger, costId })
+      corporateDocument = await getCostCenterDocument({ 
+        masterdata, 
+        logger, 
+        costId
+      })
     }
 
     const fields = {

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -520,7 +520,7 @@ const Users = {
       const orgDetails = await getOranizationDetails({
         masterdata,
         logger,
-        orgId
+        orgId,
       })
       tradeName = orgDetails?.tradeName
       corporateName = orgDetails?.name
@@ -531,7 +531,7 @@ const Users = {
       corporateDocument = await getCostCenterDocument({
         masterdata,
         logger,
-        costId
+        costId,
       })
     }
 

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -517,20 +517,20 @@ const Users = {
     let tradeName = ''
     let corporateName = ''
     if (orgId) {
-      const orgDetails = await getOranizationDetails({ 
-      masterdata, 
-      logger, 
-      orgId
-    })
+      const orgDetails = await getOranizationDetails({
+        masterdata,
+        logger,
+        orgId
+      })
       tradeName = orgDetails?.tradeName
       corporateName = orgDetails?.name
     }
 
     let corporateDocument = ''
     if (costId) {
-      corporateDocument = await getCostCenterDocument({ 
-        masterdata, 
-        logger, 
+      corporateDocument = await getCostCenterDocument({
+        masterdata,
+        logger,
         costId
       })
     }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3475,7 +3475,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Is necessary to fill in the organization's data when a B2B user is created, therefore, the following fields were added to the 'AddUser' and 'UpdateUser' methods

- isCorporate
- tradeName
- corporateName
- corporateDocument

