### PR TITLE
fix: allow storefront-permission call b2b-organizaiton-graphql when is enable to validate token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- add a check condition for the caller, to allow requests from storefront-permissions in the flow create session.
+
 ## [0.48.2] - 2024-02-21
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -24,7 +24,9 @@ type Query {
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
 
-  getOrganizationById(id: ID): Organization @cacheControl(scope: PRIVATE)
+  getOrganizationById(id: ID): Organization
+    @cacheControl(scope: PRIVATE)
+    @checkUserAccess
   getOrganizationByIdStorefront(id: ID): Organization
     @withSession
     @cacheControl(scope: PRIVATE)
@@ -56,6 +58,7 @@ type Query {
   ): CostCenterResult @withSession @cacheControl(scope: PRIVATE)
   getCostCenterById(id: ID!): CostCenter
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
+    @checkUserAccess
   getCostCenterByIdStorefront(id: ID): CostCenter
     @withSession
     @cacheControl(scope: PRIVATE, maxAge: SHORT)

--- a/manifest.json
+++ b/manifest.json
@@ -54,9 +54,6 @@
       "name": "vtex.storefront-permissions:resolve-graphql"
     },
     {
-      "name": "vtex.graphql-server:resolve-graphql"
-    },
-    {
       "name": "template-criar"
     },
     {

--- a/node/service.json
+++ b/node/service.json
@@ -27,6 +27,18 @@
     "requestCancellation": {
       "path": "/_v/private/b2b/checkout/pub/orders/:orderId/user-cancel-request",
       "public": true
+    },
+    "__graphql": {
+      "path": "/_v/graphql",
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["get"],
+          "principals": [
+            "vrn:apps:*:{{account}}:*:app/vtex.storefront-permissions@*"
+          ]
+        }
+      ]
     }
   }
 }

--- a/policies.json
+++ b/policies.json
@@ -1,18 +1,5 @@
 [
   {
-    "name": "resolve-graphql",
-    "description": "Allows access to resolve a graphql request",
-    "statements": [
-      {
-        "actions": ["post", "get"],
-        "effect": "allow",
-        "resources": [
-          "vrn:vtex.b2b-organizations-graphql:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
-        ]
-      }
-    ]
-  },
-  {
     "name": "outbound-access",
     "attrs": {
       "host": "rc.vtex.com",


### PR DESCRIPTION
#### What problem is this solving?

- We have an integration between storefront-permissions and b2b-organizations, and it is necessary to validate authentication in the request. But for some reason the storefront-permissions can't forward the cookie headers, and the token doesn't come in b2b-organization-graphql.

So, we change the integration structure and the graphql server intermediation to use the header `x-vtex-caller` as `vtex.storefront-permissions` and allow in b2b-organizations.

#### How to test it?

- Log in the b2b store

[Workspace](https://security--b2bsuite.myvtex.com/)
