### PR TITLE
fix: policies config rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Policies config rollback for graphql operations. Enable configuration.
+
 ## [0.48.3] - 2024-02-27
 
 ### Fixed

--- a/policies.json
+++ b/policies.json
@@ -1,5 +1,18 @@
 [
   {
+    "name": "resolve-graphql",
+    "description": "Allows access to resolve a graphql request",
+    "statements": [
+      {
+        "actions": ["post", "get"],
+        "effect": "allow",
+        "resources": [
+          "vrn:vtex.b2b-organizations-graphql:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
+        ]
+      }
+    ]
+  },
+  {
     "name": "outbound-access",
     "attrs": {
       "host": "rc.vtex.com",


### PR DESCRIPTION
#### What problem is this solving?

When we deployed the previous version, the integration for other apps was broken. Rollback the configuration.

#### How to test it?

- Open the quotes page
- Create a new
- The success message is show.

[Workspace](https://security--b2bsuite.myvtex.com/)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-organizations-graphql/assets/5332361/cf1d4602-1656-44e7-b89e-6490ba9dfcfe)
