### PR TITLE
fix: skip auth token validation for b2b-checkout-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip auth token validation when the x-vtex-caller is b2b-checkout-settings
+
 ## [0.48.4] - 2024-02-28
 
 ### Fixed

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -28,6 +28,9 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
       if (
         context.headers?.['x-vtex-caller']?.indexOf(
           'vtex.storefront-permissions'
+        ) !== -1 ||
+        context.headers?.['x-vtex-caller']?.indexOf(
+          'vtex.b2b-checkout-settings'
         ) !== -1
       ) {
         return resolve(root, args, context, info)


### PR DESCRIPTION
#### What problem is this solving?

We added the token validation for `getOrganizationById` and `getCostCenterById`, but for some reason the app doesn't send the token header when called by the endpoint `/_v/private/b2b-checkout-settings/`.

#### How to test it?

- Add a product in cart
- Go to checkout 

[Workspace](https://security--b2bsuite.myvtex.com/)
