### PR TITLE
Fix getCostCenterById error when not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- Fix getCostCenterById query when the cost center is not found
+
 ## [0.49.0] - 2024-03-20
 
 ### Added

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -97,7 +97,7 @@ const costCenters = {
       })
 
       /* MasterData client returns empty string when it doesn't find the document */
-      if (result as unknown as string !== '') {
+      if ((result as unknown as string) !== '') {
         result.addresses = await addMissingAddressIds(result, ctx)
       }
 

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -95,8 +95,11 @@ const costCenters = {
         fields: COST_CENTER_FIELDS,
         id,
       })
-
-      result.addresses = await addMissingAddressIds(result, ctx)
+      
+      /* MasterData client returns empty string when it doesn't find the document */
+      if ((result as unknown) as string !== '') {
+        result.addresses = await addMissingAddressIds(result, ctx)
+      }
 
       return result
     } catch (error) {

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -95,9 +95,9 @@ const costCenters = {
         fields: COST_CENTER_FIELDS,
         id,
       })
-      
+
       /* MasterData client returns empty string when it doesn't find the document */
-      if ((result as unknown) as string !== '') {
+      if (result as unknown as string !== '') {
         result.addresses = await addMissingAddressIds(result, ctx)
       }
 


### PR DESCRIPTION
#### What problem is this solving?

When requesting the query getCostCenterById with an id that is not registered, the query is returning an error instead of empty result, as the getOrganizationById query does.

#### How to test it?

[Workspace](https://jamal--ewne.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

Current behavior:
<img width="1250" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/3091668/825c4037-a3d2-43f1-8f59-964449b9d522">

Expected behavior (as this PR fixes):
<img width="1251" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/3091668/7c13e145-24a4-44dd-a13b-c6ae273b56c5">

Compared behavior with getOrganizationById:
<img width="1241" alt="image" src="https://github.com/vtex-apps/b2b-organizations-graphql/assets/3091668/00ac60c6-5e0f-4c3e-8a37-1a7e8cb0ce5b">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXhzdXpzZXV1dHBrMjI3OTQwaGNjaDExODI3eTF5aXlkd2t0Y2I5eSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TpegB7FzEXfnWlrorG/giphy.gif)
