### PR TITLE
fix: set sender app as b2b-organizations on checkUserPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- Use b2b-organizations app name on checkUserPermission to correctly get the user permissions
+
 ## [0.49.1] - 2024-03-28
 
 ### Fix

--- a/node/resolvers/directives/withPermissions.ts
+++ b/node/resolvers/directives/withPermissions.ts
@@ -9,7 +9,9 @@ import type StorefrontPermissions from '../../clients/storefrontPermissions'
 export const getUserPermission = async (
   storefrontPermissions: StorefrontPermissions
 ) => {
-  const result = await storefrontPermissions.checkUserPermission()
+  const result = await storefrontPermissions.checkUserPermission(
+    'vtex.b2b-organizations@0.x'
+  )
 
   return result?.data?.checkUserPermission ?? null
 }


### PR DESCRIPTION
#### What problem is this solving?

The client can't add a user because the role isn't set correctly, just therefore, the storefront-permissions are returned by the app name sent to the sender in the extension persisted query.

Set the b2b-organizations app name on checkUserPermission to correctly get the user permissions.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://orders.lyonbakery.com/account/?workspace=t1013317)
