### PR TITLE
chore: add metric to check access directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add metric to check access directives
+
 ## [0.49.3] - 2024-04-24
 
 ### Fixed

--- a/node/resolvers/directives/auditAccess.ts
+++ b/node/resolvers/directives/auditAccess.ts
@@ -26,6 +26,7 @@ export class AuditAccess extends SchemaDirectiveVisitor {
       request,
     } = context
 
+    const userAgent = request.headers['user-agent'] as string
     const operation = field.astNode?.name?.value ?? request.url
     const forwardedHost = request.headers['x-forwarded-host'] as string
     const caller =
@@ -43,6 +44,7 @@ export class AuditAccess extends SchemaDirectiveVisitor {
 
     const authMetric = new AuthMetric(account, {
       caller,
+      userAgent,
       forwardedHost,
       hasAdminToken,
       hasApiToken,

--- a/node/resolvers/directives/checkAdminAccess.ts
+++ b/node/resolvers/directives/checkAdminAccess.ts
@@ -21,15 +21,17 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
       } = context
 
       // send metric to collect data about caller and tokens used in the request
-      const operation = field.astNode?.name?.value ?? context.request.url
+      const operation = field.astNode?.name?.value ?? context?.request?.url
       const metric = new AuthMetric(
-        context.vtex.account,
+        context?.vtex?.account,
         {
-          caller: context.request.header['x-vtex-caller'] as string,
-          userAgent: context.request.header['user-agent'] as string,
-          forwardedHost: context.request.header['x-forwarded-host'] as string,
+          caller: context?.request?.headers['x-vtex-caller'] as string,
+          userAgent: context?.request?.headers['user-agent'] as string,
+          forwardedHost: context?.request?.headers[
+            'x-forwarded-host'
+          ] as string,
           hasAdminToken: !!adminUserAuthToken,
-          hasApiToken: !!context.request.headers['vtex-api-apptoken'],
+          hasApiToken: !!context?.request?.headers['vtex-api-apptoken'],
           hasStoreToken: false,
           operation,
         },

--- a/node/resolvers/directives/checkAdminAccess.ts
+++ b/node/resolvers/directives/checkAdminAccess.ts
@@ -3,6 +3,8 @@ import { AuthenticationError, ForbiddenError } from '@vtex/api'
 import type { GraphQLField } from 'graphql'
 import { defaultFieldResolver } from 'graphql'
 
+import sendAuthMetric, { AuthMetric } from '../../utils/metrics/auth'
+
 export class CheckAdminAccess extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
@@ -17,6 +19,24 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
         vtex: { adminUserAuthToken, logger },
         clients: { identity },
       } = context
+
+      // send metric to collect data about caller and tokens used in the request
+      const operation = field.astNode?.name?.value ?? context.request.url
+      const metric = new AuthMetric(
+        context.vtex.account,
+        {
+          caller: context.request.header['x-vtex-caller'] as string,
+          userAgent: context.request.header['user-agent'] as string,
+          forwardedHost: context.request.header['x-forwarded-host'] as string,
+          hasAdminToken: !!adminUserAuthToken,
+          hasApiToken: !!context.request.headers['vtex-api-apptoken'],
+          hasStoreToken: false,
+          operation,
+        },
+        'CheckAdminAccess'
+      )
+
+      sendAuthMetric(context, logger, metric)
 
       let token =
         adminUserAuthToken ?? (context?.headers.vtexidclientautcookie as string)

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -21,15 +21,17 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
       } = context
 
       // send metric to collect data about caller and tokens used in the request
-      const operation = field.astNode?.name?.value ?? context.request.url
+      const operation = field.astNode?.name?.value ?? context?.request?.url
       const metric = new AuthMetric(
-        context.vtex.account,
+        context?.vtex?.account,
         {
-          caller: context.request.header['x-vtex-caller'] as string,
-          userAgent: context.request.header['user-agent'] as string,
-          forwardedHost: context.request.header['x-forwarded-host'] as string,
+          caller: context?.request?.headers['x-vtex-caller'] as string,
+          userAgent: context?.request?.headers['user-agent'] as string,
+          forwardedHost: context?.request?.headers[
+            'x-forwarded-host'
+          ] as string,
           hasAdminToken: !!adminUserAuthToken,
-          hasApiToken: !!context.request.headers['vtex-api-apptoken'],
+          hasApiToken: !!context?.request?.headers['vtex-api-apptoken'],
           hasStoreToken: !!storeUserAuthToken,
           operation,
         },

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -3,6 +3,8 @@ import type { GraphQLField } from 'graphql'
 import { defaultFieldResolver } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
+import sendAuthMetric, { AuthMetric } from '../../utils/metrics/auth'
+
 export class CheckUserAccess extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
@@ -17,6 +19,24 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         vtex: { adminUserAuthToken, storeUserAuthToken, logger },
         clients: { identity, vtexId },
       } = context
+
+      // send metric to collect data about caller and tokens used in the request
+      const operation = field.astNode?.name?.value ?? context.request.url
+      const metric = new AuthMetric(
+        context.vtex.account,
+        {
+          caller: context.request.header['x-vtex-caller'] as string,
+          userAgent: context.request.header['user-agent'] as string,
+          forwardedHost: context.request.header['x-forwarded-host'] as string,
+          hasAdminToken: !!adminUserAuthToken,
+          hasApiToken: !!context.request.headers['vtex-api-apptoken'],
+          hasStoreToken: !!storeUserAuthToken,
+          operation,
+        },
+        'CheckUserAccess'
+      )
+
+      sendAuthMetric(context, logger, metric)
 
       let token = adminUserAuthToken
 

--- a/node/utils/metrics/auth.ts
+++ b/node/utils/metrics/auth.ts
@@ -7,6 +7,7 @@ export interface AuthAuditMetric {
   operation: string
   forwardedHost: string
   caller: string
+  userAgent: string
   role?: string
   permissions?: string[]
   hasAdminToken: boolean
@@ -21,11 +22,11 @@ export class AuthMetric implements Metric {
   public readonly fields: AuthAuditMetric
   public readonly name = B2B_METRIC_NAME
 
-  constructor(account: string, fields: AuthAuditMetric) {
+  constructor(account: string, fields: AuthAuditMetric, description?: string) {
     this.account = account
     this.fields = fields
-    this.kind = 'b2b-organization-auth-event'
-    this.description = 'Auth metric event'
+    this.kind = 'b2b-organizations-graphql-auth-event'
+    this.description = description ?? 'Auth metric event'
   }
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Add metric to check access directives. With these metrics we can collect data about how these APIs are being used/called.

### Testing
Data example collected from redshift:

`{"name":"b2b-suite-buyerorg-data","account":"b2bstoreqa","fields":{"caller":"vtex.graphql-server@1.67.8","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36","forwardedHost":"testsec--b2bstoreqa.myvtex.com","hasAdminToken":true,"hasApiToken":false,"hasStoreToken":false,"operation":"getCostCenterByIdStorefront"},"kind":"b2b-organizations-graphql-auth-event","description":"CheckUserAccess"}`