### PR TITLE
fix: update paymentTerms on costCenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix check access directive by allowing appkey tokens for authentication
+
 ## [0.49.5] - 2024-05-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.49.6] - 2024-06-03
+
 ### Fixed
 - Fix check access directive by allowing appkey tokens for authentication
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "vtex",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.b2b-organizations",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "dependencies": {
     "@types/lodash": "4.14.74",
     "@vtex/api": "6.46.1",

--- a/node/resolvers/directives/checkAdminAccess.ts
+++ b/node/resolvers/directives/checkAdminAccess.ts
@@ -23,7 +23,8 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
       const { hasAdminToken, hasValidAdminToken, hasCurrentValidAdminToken } =
         await validateAdminToken(context, adminUserAuthToken as string)
 
-      const { hasApiToken, hasValidApiToken } = await validateApiToken(context)
+      const { hasApiToken, hasValidApiToken, hasCurrentValidApiToken } =
+        await validateApiToken(context)
 
       const hasStoreToken = !!storeUserAuthToken // we don't need to validate store token
 
@@ -53,7 +54,7 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
 
       sendAuthMetric(context, logger, auditMetric)
 
-      if (!hasAdminToken) {
+      if (!hasAdminToken && !hasApiToken) {
         logger.warn({
           message: 'CheckAdminAccess: No token provided',
           userAgent,
@@ -69,7 +70,7 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
         throw new AuthenticationError('No token was provided')
       }
 
-      if (!hasCurrentValidAdminToken) {
+      if (!hasCurrentValidAdminToken && !hasCurrentValidApiToken) {
         logger.warn({
           message: 'CheckAdminAccess: Invalid token',
           userAgent,

--- a/node/resolvers/directives/checkUserAccess.ts
+++ b/node/resolvers/directives/checkUserAccess.ts
@@ -27,7 +27,8 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
       const { hasAdminToken, hasValidAdminToken, hasCurrentValidAdminToken } =
         await validateAdminToken(context, adminUserAuthToken as string)
 
-      const { hasApiToken, hasValidApiToken } = await validateApiToken(context)
+      const { hasApiToken, hasValidApiToken, hasCurrentValidApiToken } =
+        await validateApiToken(context)
 
       const { hasStoreToken, hasValidStoreToken, hasCurrentValidStoreToken } =
         await validateStoreToken(context, storeUserAuthToken as string)
@@ -72,7 +73,7 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         return resolve(root, args, context, info)
       }
 
-      if (!hasAdminToken && !hasStoreToken) {
+      if (!hasAdminToken && !hasStoreToken && !hasApiToken) {
         logger.warn({
           message: 'CheckUserAccess: No token provided',
           userAgent,
@@ -88,7 +89,11 @@ export class CheckUserAccess extends SchemaDirectiveVisitor {
         throw new AuthenticationError('No token was provided')
       }
 
-      if (!hasCurrentValidAdminToken && !hasCurrentValidStoreToken) {
+      if (
+        !hasCurrentValidAdminToken &&
+        !hasCurrentValidStoreToken &&
+        !hasCurrentValidApiToken
+      ) {
         logger.warn({
           message: `CheckUserAccess: Invalid token`,
           userAgent,

--- a/node/resolvers/directives/helper.ts
+++ b/node/resolvers/directives/helper.ts
@@ -44,6 +44,7 @@ export const validateApiToken = async (
 ): Promise<{
   hasApiToken: boolean
   hasValidApiToken: boolean
+  hasCurrentValidApiToken: boolean
 }> => {
   const {
     clients: { identity },
@@ -54,6 +55,9 @@ export const validateApiToken = async (
   const appKey = context?.headers['vtex-api-appkey'] as string
   const hasApiToken = !!(apiToken?.length && appKey?.length)
   let hasValidApiToken = false
+
+  // this is used to check if the token is valid by current standards
+  let hasCurrentValidApiToken = false
 
   if (hasApiToken) {
     try {
@@ -66,6 +70,13 @@ export const validateApiToken = async (
         token,
       })
 
+      // we set this flag to true if the token is valid by current standards
+      // in the future we should remove this line
+      hasCurrentValidApiToken = true
+      // keeping this behavior for now, but we should remove it in the future as well
+      context.cookies.set('VtexIdclientAutCookie', token)
+      context.vtex.adminUserAuthToken = token
+
       if (authUser?.audience === 'admin') {
         hasValidApiToken = true
       }
@@ -74,7 +85,7 @@ export const validateApiToken = async (
     }
   }
 
-  return { hasApiToken, hasValidApiToken }
+  return { hasApiToken, hasValidApiToken, hasCurrentValidApiToken }
 }
 
 export const validateStoreToken = async (

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3475,7 +3475,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "lint-staged": "^10.5.1",
     "prettier": "^2.2.0",
     "typescript": "3.9.7"
+  },
+  "dependencies": {
+    "p-limit": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,6 +1855,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-5.0.0.tgz#6946d5b7140b649b7a33a027d89b4c625b3a5985"
+  integrity sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
@@ -2462,3 +2469,8 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==


### PR DESCRIPTION
#### What problem is this solving?

Updating payment terms in the organization details UI does not apply to B2B checkout settings.

This behavior occurs because the update occurs only for the organization, but B2B checkout settings use cost center information, which is not updated by the organization details UI.

#### How to test it?

- Create an organization;
- In the organization details UI, update the payment terms;
- Access the website, assemble a cart and access checkout; Payment terms will remain the same.

[Workspace](https://giurigaud--b2bstore005.myvtex.com/admin/b2b-organizations/organizations/org-test-3/#/pay-terms)

#### Screenshots or example usage:

https://github.com/vtex-apps/b2b-organizations-graphql/assets/62848434/ce6d96c0-40de-419e-8d4f-5c4d60737a03


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/YnBntKOgnUSBkV7bQH/giphy.gif?cid=790b7611nknxet26mzoxpqh3ng0pbhxzg4ta0s0wbfuszqxz&ep=v1_gifs_search&rid=giphy.gif&ct=g)
