### PR TITLE
fix: provide app token to storefront-permissions calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Provide app token on calls to storefront-permissions app
+
 ## [0.51.1] - 2024-07-22
 
 ### Added

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -314,9 +314,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }
 
   private getTokenToHeader = () => {
-    // provide authToken (app token) as this is a call between b2b suite apps
-    // (with a fallback to the admin user token if the app token is not available)
-    const adminToken = this.context.authToken ?? this.context.adminUserAuthToken
+    // provide authToken (app token) as an admin token as this is a call
+    // between b2b suite apps and no further token validation is needed
+    const adminToken = this.context.authToken
     const userToken = this.context.storeUserAuthToken ?? null
     const { sessionToken, account } = this.context
 

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -314,7 +314,9 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }
 
   private getTokenToHeader = () => {
-    const adminToken = this.context.adminUserAuthToken ?? this.context.authToken
+    // provide authToken (app token) as this is a call between b2b suite apps
+    // (with a fallback to the admin user token if the app token is not available)
+    const adminToken = this.context.authToken ?? this.context.adminUserAuthToken
     const userToken = this.context.storeUserAuthToken ?? null
     const { sessionToken, account } = this.context
 


### PR DESCRIPTION
#### What problem is this solving?

Provide app token on calls to storefront-permissions instead of admin/user tokens as these were already validated at this point.