### PR TITLE
feat: add paging support to getSellers query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add new parameter `paging` on `getSellers` query to allow pagination
+- Add new `getSellersPaginated` query to allow pagination on sellers query
 
 ## [0.51.2] - 2024-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new parameter `paging` on `getSellers` query to allow pagination
+
 ## [0.51.2] - 2024-07-30
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -110,25 +110,25 @@ type Query {
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
-  getSellersPaginated(paging: PaginationInput): GetSellersResponse
-    @checkAdminAccess
-    @cacheControl(scope: PRIVATE)
+  getSellersPaginated(
+    args: GetSellersPaginatedArgsInput
+  ): GetSellersPaginatedResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
 }
 
-input PaginationInput {
-  from: Int
-  to: Int
+input GetSellersPaginatedArgsInput {
+  page: Int
+  pageSize: Int
 }
 
 type PaginationResponse {
-  from: Int
-  to: Int
+  page: Int
+  pageSize: Int
   total: Int
 }
 
-type GetSellersResponse {
+type GetSellersPaginatedResponse {
   items: [Seller]
-  paging: PaginationResponse
+  pagination: PaginationResponse
 }
 
 type Mutation {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -111,7 +111,7 @@ type Query {
     @auditAccess
   getSellers: [Seller] @validateAdminUserAccess @cacheControl(scope: PRIVATE)
   getSellersPaginated(page: Int, pageSize: Int): GetSellersPaginatedResponse
-    @checkAdminAccess
+    @validateAdminUserAccess
     @cacheControl(scope: PRIVATE)
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -110,14 +110,9 @@ type Query {
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
   getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
-  getSellersPaginated(
-    args: GetSellersPaginatedArgsInput
-  ): GetSellersPaginatedResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
-}
-
-input GetSellersPaginatedArgsInput {
-  page: Int
-  pageSize: Int
+  getSellersPaginated(page: Int, pageSize: Int): GetSellersPaginatedResponse
+    @checkAdminAccess
+    @cacheControl(scope: PRIVATE)
 }
 
 type PaginationResponse {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -109,7 +109,8 @@ type Query {
   getB2BSettings: B2BSettings
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
-  getSellers(paging: PaginationInput): GetSellersResponse
+  getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
+  getSellersPaginated(paging: PaginationInput): GetSellersResponse
     @checkAdminAccess
     @cacheControl(scope: PRIVATE)
 }
@@ -127,7 +128,7 @@ type PaginationResponse {
 
 type GetSellersResponse {
   items: [Seller]
-  pagination: PaginationResponse
+  paging: PaginationResponse
 }
 
 type Mutation {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -109,7 +109,25 @@ type Query {
   getB2BSettings: B2BSettings
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
     @auditAccess
-  getSellers: [Seller] @checkAdminAccess @cacheControl(scope: PRIVATE)
+  getSellers(paging: PaginationInput): GetSellersResponse
+    @checkAdminAccess
+    @cacheControl(scope: PRIVATE)
+}
+
+input PaginationInput {
+  from: Int
+  to: Int
+}
+
+type PaginationResponse {
+  from: Int
+  to: Int
+  total: Int
+}
+
+type GetSellersResponse {
+  items: [Seller]
+  pagination: PaginationResponse
 }
 
 type Mutation {

--- a/node/clients/sellers.ts
+++ b/node/clients/sellers.ts
@@ -19,7 +19,16 @@ export default class SellersClient extends JanusClient {
     })
   }
 
-  public async getSellers(): Promise<{ items: Seller[] }> {
-    return this.http.get(SELLERS_PATH)
+  public async getSellers(paging?: {
+    from: number
+    to: number
+  }): Promise<{ items: Seller[] }> {
+    return this.http.get(SELLERS_PATH, {
+      metric: 'sellers-get',
+      params: {
+        from: paging?.from ?? 0,
+        to: paging?.to ?? 100,
+      },
+    })
   }
 }

--- a/node/clients/sellers.ts
+++ b/node/clients/sellers.ts
@@ -9,6 +9,15 @@ export interface Seller {
   email: string
 }
 
+export interface GetSellersResponse {
+  items: Seller[]
+  paging: {
+    from: number
+    to: number
+    total: number
+  }
+}
+
 export default class SellersClient extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
@@ -22,7 +31,7 @@ export default class SellersClient extends JanusClient {
   public async getSellers(paging?: {
     from: number
     to: number
-  }): Promise<{ items: Seller[] }> {
+  }): Promise<GetSellersResponse> {
     return this.http.get(SELLERS_PATH, {
       metric: 'sellers-get',
       params: {

--- a/node/clients/sellers.ts
+++ b/node/clients/sellers.ts
@@ -35,9 +35,7 @@ export default class SellersClient extends JanusClient {
   }
 
   public async getSellers(): Promise<{ items: Seller[] }> {
-    return this.http.get(SELLERS_PATH, {
-      metric: 'sellers-get',
-    })
+    return this.http.get(SELLERS_PATH)
   }
 
   public async getSellersPaginated(
@@ -53,18 +51,16 @@ export default class SellersClient extends JanusClient {
       ...opts,
     }
 
-    const { pageSize } = argsWithDefaults
+    const { page, pageSize } = argsWithDefaults
 
-    const page = Math.max(1, argsWithDefaults.page)
+    if (page < 1 || pageSize < 1) {
+      throw new Error(
+        `Please make sure you are passing valid values for 'page' and 'pageSize'. Received: page=${page}, pageSize=${pageSize}`
+      )
+    }
 
     const from = (page - 1) * pageSize
     const to = page * pageSize
-
-    if (from >= to) {
-      throw new Error(
-        'Invalid pagination values: `from` should be less than `to`. Please make sure you are passing valid values for `page` and `pageSize`.'
-      )
-    }
 
     const result = await this.http.get<{
       items: Seller[]

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -47,7 +47,24 @@ const B2BSettings = {
 
     return settings
   },
-  getSellers: async (
+  getSellers: async (_: void, __: void, ctx: Context) => {
+    const {
+      clients: { sellers },
+    } = ctx
+
+    try {
+      return (await sellers.getSellers())?.items
+    } catch (e) {
+      if (e.message) {
+        throw new GraphQLError(e.message)
+      } else if (e.response?.data?.message) {
+        throw new GraphQLError(e.response.data.message)
+      } else {
+        throw new GraphQLError(e)
+      }
+    }
+  },
+  getSellersPaginated: async (
     _: void,
     args: {
       paging?: {
@@ -64,7 +81,7 @@ const B2BSettings = {
     const { paging } = args
 
     try {
-      return sellers.getSellers(paging)
+      return await sellers.getSellers(paging)
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -65,7 +65,7 @@ const B2BSettings = {
     } = ctx
 
     try {
-      return await sellers.getSellers(options)
+      return await sellers.getSellersPaginated(options)
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -53,21 +53,11 @@ const B2BSettings = {
       clients: { sellers },
     } = ctx
 
-    try {
-      return (await sellers.getSellers())?.items
-    } catch (e) {
-      if (e.message) {
-        throw new GraphQLError(e.message)
-      } else if (e.response?.data?.message) {
-        throw new GraphQLError(e.response.data.message)
-      } else {
-        throw new GraphQLError(e)
-      }
-    }
+    return (await sellers.getSellers())?.items
   },
   getSellersPaginated: async (
     _: void,
-    { args }: { args: GetSellersOpts },
+    options: GetSellersOpts,
     ctx: Context
   ) => {
     const {
@@ -75,7 +65,7 @@ const B2BSettings = {
     } = ctx
 
     try {
-      return await sellers.getSellers(args)
+      return await sellers.getSellers(options)
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -47,12 +47,33 @@ const B2BSettings = {
 
     return settings
   },
-  getSellers: async (_: void, __: void, ctx: Context) => {
+  getSellers: async (
+    _: void,
+    args: {
+      paging?: {
+        from: number
+        to: number
+      }
+    },
+    ctx: Context
+  ) => {
     const {
       clients: { sellers },
     } = ctx
 
-    return (await sellers.getSellers())?.items
+    const { paging } = args
+
+    try {
+      return sellers.getSellers(paging)
+    } catch (e) {
+      if (e.message) {
+        throw new GraphQLError(e.message)
+      } else if (e.response?.data?.message) {
+        throw new GraphQLError(e.response.data.message)
+      } else {
+        throw new GraphQLError(e)
+      }
+    }
   },
 }
 

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -1,6 +1,7 @@
 import GraphQLError from '../../utils/GraphQLError'
 import checkConfig from '../config'
 import type { B2BSettingsInput } from '../../typings'
+import type { GetSellersOpts } from '../../clients/sellers'
 
 const B2BSettings = {
   getB2BSettings: async (_: void, __: void, ctx: Context) => {
@@ -66,22 +67,15 @@ const B2BSettings = {
   },
   getSellersPaginated: async (
     _: void,
-    args: {
-      paging?: {
-        from: number
-        to: number
-      }
-    },
+    { args }: { args: GetSellersOpts },
     ctx: Context
   ) => {
     const {
       clients: { sellers },
     } = ctx
 
-    const { paging } = args
-
     try {
-      return await sellers.getSellers(paging)
+      return await sellers.getSellers(args)
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3475,7 +3475,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The `getSellersPaginated` query now accepts a `paging` input parameter, allowing the client to specify the range of sellers to retrieve. The response includes a `paging` object with information about the total number of sellers and the range of sellers returned. This change improves the flexibility and efficiency of retrieving seller data.

#### How to test it?

```graphql
query GetSellersPaginated($page: Int, $pageSize: Int) {
  getSellersPaginated(page: $page, pageSize: $pageSize) {
    pagination {
      page
      pageSize
      total
    }
    items {
      id
      name
      email
    }
  }
}

```

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l0amJzVHIAfl7jMDos/giphy.gif?cid=82a1493brdqdanivqz2u3ntxdsrxpwt7ue10aoe2pwfufbb0&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
