### PR TITLE
feat: add payment terms to default cost center input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add paymentTerms field to cost center input on mutations
+
 ## [0.54.0] - 2024-08-12
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -563,6 +563,7 @@ input DefaultCostCenterInput {
   id: String
   name: String
   address: AddressInput
+  paymentTerms: [PaymentTermInput]
   phoneNumber: String
   businessDocument: String
   customFields: [CustomFieldInput]


### PR DESCRIPTION
#### What problem is this solving?

When I try to create an organization with cost centers, I cannot add the payments terms because the input typing has not been updated.

#### How to test it?

create an organization with cost centers by adding payments terms to the payload

[Workspace] https://jwp755--jwpepperdev.myvtex.com/

#### Screenshots or example usage:

```
mutation {
  createOrganizationAndCostCentersWithId(input: {name: "PaymentTerms3", tradeName: "PaymentTerms3", defaultCostCenter: {name: "PaymentTerms3", address: {addressId: "0", addressType: "", addressQuery: "", postalCode: "PaymentTerms3", country: "AFG", receiverName: "PaymentTerms3", city: "PaymentTerms3", state: "", street: "PaymentTerms3", number: "", neighborhood: "", geoCoordinates: [], reference: ""}, paymentTerms: [{id: "999999", name: "Credit card"}], phoneNumber: "1", businessDocument: "", stateRegistration: ""}, b2bCustomerAdmin: {firstName: "", lastName: "", email: "emanuel@m3ecommerce.com"}, costCenters: [], priceTables: [], salesChannel: null, sellers: null, customFields: []}) {
    id
    href
    status
  }
}
```


#### How does this PR make you feel?

[:https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHhmZm94YXJtZzNmeGVrbWJtdXJjeG5renZtd3p0NXdlYWMwdmpxeSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1fMjj5j2Z7chq/giphy.gif:](http://giphy.com/)
