### PR TITLE
feat: add getAccount query to retrieve account information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+Adds a new `getAccount` query to retrieve account information. It includes fields such as `id`, `name`, `accountName`, `tradingName`, and `isActive`. This query is implemented in both the GraphQL schema and the LMClient class.
+
 ## [0.55.0] - 2024-08-22
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -113,7 +113,7 @@ type Query {
   getSellersPaginated(page: Int, pageSize: Int): GetSellersPaginatedResponse
     @validateAdminUserAccess
     @cacheControl(scope: PRIVATE)
-  getAccount: Account @withSession @cacheControl(scope: PRIVATE)
+  getAccount: Account @validateAdminUserAccess @cacheControl(scope: PRIVATE)
 }
 
 type Account {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -113,6 +113,15 @@ type Query {
   getSellersPaginated(page: Int, pageSize: Int): GetSellersPaginatedResponse
     @validateAdminUserAccess
     @cacheControl(scope: PRIVATE)
+  getAccount: Account @withSession @cacheControl(scope: PRIVATE)
+}
+
+type Account {
+  id: ID
+  name: String
+  accountName: String
+  tradingName: String
+  isActive: Boolean
 }
 
 type PaginationResponse {

--- a/node/clients/LMClient.ts
+++ b/node/clients/LMClient.ts
@@ -24,7 +24,59 @@ export default class LMClient extends ExternalClient {
     })
   }
 
+  public getAccount = async () => {
+    return this.get<GetAccountResponse>(`/api/license-manager/account`).then(
+      (res) => {
+        return res
+      }
+    )
+  }
+
   protected get = <T>(url: string) => {
     return this.http.get<T>(url)
   }
+}
+
+interface GetAccountResponse {
+  isActive: boolean
+  id: string
+  name: string
+  accountName: string
+  lv: unknown
+  isOperating: boolean
+  defaultUrl: unknown
+  district: unknown
+  country: unknown
+  complement: unknown
+  compunknownName: string
+  cnpj: string
+  haveParentAccount: boolean
+  parentAccountId: unknown
+  parentAccountName: unknown
+  city: unknown
+  address: unknown
+  logo: unknown
+  hasLogo: boolean
+  number: unknown
+  postalCode: unknown
+  state: unknown
+  telephone: string
+  tradingName: string
+  licenses: unknown[]
+  sponsor: {
+    name: string
+    email: string
+    phone: string
+  }
+  contact: {
+    name: string
+    email: string
+    phone: string
+  }
+  operationDate: unknown
+  inactivationDate: unknown
+  creationDate: string
+  hosts: unknown[]
+  sites: unknown[]
+  appKeys: unknown[]
 }

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -76,6 +76,21 @@ const B2BSettings = {
       }
     }
   },
+  getAccount: async (_: void, __: void, ctx: Context) => {
+    const {
+      clients: { lm },
+    } = ctx
+
+    return lm.getAccount().catch((e) => {
+      if (e.message) {
+        throw new GraphQLError(e.message)
+      } else if (e.response?.data?.message) {
+        throw new GraphQLError(e.response.data.message)
+      } else {
+        throw new GraphQLError(e)
+      }
+    })
+  },
 }
 
 export default B2BSettings


### PR DESCRIPTION
#### What problem is this solving?

There is a discrepancy between the name used in the product search and the name displayed in the B2B suite. The search uses the "trade name" registered in Account Management, while the B2B suite uses the "seller name" defined in Seller Management. This difference in naming can result in an inconsistent display of available products, since the search may not return products if the names registered in the two modules differ.

To resolve this issue and align the user experience, it was necessary to adjust the B2B suite to use the "trade name" from Account Management instead of the "seller name" from Seller Management. This will ensure that products are displayed correctly in the search and in the B2B suite interface, regardless of the name registered in Seller Management.

To achieve this, a new query `getAccount` was created to retrieve account data and use it when assigning a salesperson to an organization.

#### How to test it?

```graphql
query GetAccount {
  getAccount {
    id
    name
    accountName
    tradingName
    isActive
  }
}
```

[Workspace](https://icaroov--b2bstore005.myvtex.com)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/mgqefqwSbToPe/giphy.gif?cid=790b7611doyck2z6htesmnuuk1rqytvb8v5sn3sow4eq75el&ep=v1_gifs_search&rid=giphy.gif&ct=g)
