### PR TITLE
Add new query getOrganizationsByEmailPaginated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+
+- Add new `getOrganizationsByEmailPaginated` query to allow pagination on organizations by email query
+
 ## [0.55.0] - 2024-08-22
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -92,6 +92,10 @@ type Query {
   getOrganizationsByEmail(email: String): [B2BOrganization]
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
+  
+  getOrganizationsByEmailPaginated(email: String, page: Int, pageSize: Int): B2BOrganizationPagination
+    @checkUserAccess
+    @cacheControl(scope: PRIVATE)
 
   checkOrganizationIsActive(id: String): Boolean
     @cacheControl(scope: PRIVATE)
@@ -473,6 +477,11 @@ type B2BOrganization {
   organizationName: String
   organizationStatus: String
   costCenterName: String
+}
+
+type B2BOrganizationPagination {
+  data: [B2BOrganization]
+  pagination: Pagination
 }
 
 type SimpleRole {

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -8,6 +8,7 @@ import saveUser from '../mutations/saveUser'
 import updateUser from '../mutations/updateUser'
 import getB2BUser from '../queries/getB2BUser'
 import getOrganizationsByEmail from '../queries/getOrganizationsByEmail'
+import getOrganizationsByEmailPaginated from '../queries/getOrganizationsByEmailPaginated'
 import getPermission from '../queries/getPermission'
 import getRole from '../queries/getRole'
 import getUser from '../queries/getUser'
@@ -36,6 +37,18 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       query: getOrganizationsByEmail,
       variables: {
         email,
+      },
+    })
+  }
+
+  public getOrganizationsByEmailPaginated = async (email: string, page: number, pageSize: number): Promise<any> => {
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getOrganizationsByEmailPaginated,
+      variables: {
+        email,
+        page,
+        pageSize,
       },
     })
   }

--- a/node/index.ts
+++ b/node/index.ts
@@ -10,7 +10,7 @@ import { Clients } from './clients'
 import { resolvers } from './resolvers'
 import { schemaDirectives } from './resolvers/directives'
 
-const TIMEOUT_MS = 4000
+const TIMEOUT_MS = 10000
 
 // Create a LRU memory cache for the Status client.
 // The @vtex/api HttpClient respects Cache-Control headers and uses the provided cache.

--- a/node/queries/getOrganizationsByEmailPaginated.ts
+++ b/node/queries/getOrganizationsByEmailPaginated.ts
@@ -1,0 +1,25 @@
+import { print } from 'graphql'
+import gql from 'graphql-tag'
+
+export default print(gql`
+  query organizationsPaginated($email: String!, $page: Int, $pageSize: Int) {
+    getOrganizationsByEmailPaginated(
+      email: $email
+      page: $page
+      pageSize: $pageSize
+    ) {
+      data {
+        costId
+        orgId
+        roleId
+        id
+        clId
+      }
+      pagination {
+        page
+        pageSize
+        total
+      }
+    }
+  }
+`)


### PR DESCRIPTION
#### What problem is this solving?

This new query will allow to retrieve the users' organizations paginated.
Currently when an user is associated to a big number of organizations is generating a timeout.

This PR should be merged only when this other one is merged: https://github.com/vtex-apps/storefront-permissions/pull/157

#### How to test it?

Access https://timeoutsfp--jamalstore.myvtex.com/admin/graphql-ide
Run the query below in the b2b-organizations-graphql app

```
{
  getOrganizationsByEmailPaginated(
    email: "victor.almeida+2@vtex.com",
    page: 1
    pageSize: 25
  ) {
    data {
      id
      clId
     	costId
      orgId
      organizationName
      costCenterName
    }
    pagination {
      page
      pageSize
      total
    }
  }
}
```

[Workspace](https://timeoutsfp--jamalstore.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/10b4a5bc-180d-41d2-8dba-c2f35485765d">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex-apps/storefront-permissions/pull/157

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzFxYW03dTJjdGdwc3NnaTB1c2g4cjE0ZnZvdmpwaDFkZnFjajU3MCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT77Y1T0zY1gR5qe5O/giphy.webp)
