### PR TITLE
fix: remove error log when file not found.

### DIFF
--- a/node/resolvers/Queries/MarketingTags.ts
+++ b/node/resolvers/Queries/MarketingTags.ts
@@ -14,10 +14,14 @@ const MarketingTags = {
     try {
       return await vbase.getJSON(MARKETING_TAGS.VBASE_BUCKET, costId)
     } catch (error) {
-      logger.error({
-        error,
-        message: 'getMarketingTags.error',
-      })
+      const { data } = error.response as any
+
+      if (data.code !== 'FileNotFound') {
+        logger.error({
+          error,
+          message: 'getMarketingTags.error',
+        })
+      }
 
       return { status: 'error', message: error }
     }


### PR DESCRIPTION
#### What problem is this solving?

We got a lot of errors logs from customer that call the query but the market tags wasn't configured for the cost center.

#### How to test it?

- Call query getMarketingTags
```
curl --location 'https://marketingtags--b2bsuite.myvtex.com/_v/private/graphql/v1' \
--header 'Cookie: VtexIdclientAutCookie=TOKEN' \
--header 'Content-Type: application/json' \
--data '{"query":"query getMarketingTags ($costId: ID!) {\n    getMarketingTags (costId: $costId) {\n        tags\n    }\n}","variables":{"costId":"1234"}}'
```

[marketingtags](https://marketingtags--b2bsuite.myvtex.com/)
