### PR TITLE
fix: change GetOrganizationRequests cache control scope to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Change GetOrganizationRequests API cache control scope to private
+
 ## [0.57.0] - 2024-09-12
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -10,7 +10,7 @@ type Query {
     sortOrder: String = "DESC"
     sortedBy: String = "created"
   ): OrganizationRequestResult
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @auditAccess
   getOrganizationRequestById(id: ID!): OrganizationRequest
     @cacheControl(scope: PUBLIC, maxAge: SHORT)


### PR DESCRIPTION
#### What problem is this solving?

Change cache control scope to private for API GetOrganizationRequests. More info: https://vtex.slack.com/archives/C1Q399J9H/p1726858001951669

