### PR TITLE
fix: add token validation to getOrganizationsWithoutSalesManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new admin token validation directive to getOrganizationsWithoutSalesManager
+
 ## [0.57.1] - 2024-09-30
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -28,7 +28,7 @@ type Query {
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
-    @auditAccess
+    @@validateAdminUserAccess
 
   getOrganizationById(id: ID): Organization
     @cacheControl(scope: PRIVATE)


### PR DESCRIPTION
#### What problem is this solving?

Add admin token validation to getOrganizationsWithoutSalesManager. See more: https://vtex-dev.atlassian.net/browse/B2BTEAM-1892
