### PR TITLE
fix: add new store token validation to some APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new store user token validation directive to some APIs
+
 ## [0.57.1] - 2024-09-30
 
 ### Fixed

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -1,6 +1,7 @@
 directive @withSession on FIELD | FIELD_DEFINITION
 directive @withPermissions on FIELD | FIELD_DEFINITION
 directive @validateAdminUserAccess on FIELD | FIELD_DEFINITION
+directive @validateStoreUserAccess on FIELD | FIELD_DEFINITION
 directive @checkUserAccess on FIELD | FIELD_DEFINITION
 directive @checkAdminAccess on FIELD | FIELD_DEFINITION
 directive @auditAccess on FIELD | FIELD_DEFINITION

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -24,7 +24,7 @@ type Query {
     sortedBy: String = "name"
   ): OrganizationResult
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @checkUserAccess
+    @@validateStoreUserAccess
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)
@@ -224,7 +224,7 @@ type Mutation {
   ): MutationResponse
     @withSession
     @withPermissions
-    @checkUserAccess
+    @validateStoreUserAccess
     @cacheControl(scope: PRIVATE)
   """
   addUser will create an user with the provided parameters.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -24,7 +24,7 @@ type Query {
     sortedBy: String = "name"
   ): OrganizationResult
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
-    @@validateStoreUserAccess
+    @validateStoreUserAccess
 
   getOrganizationsWithoutSalesManager: [Organization]
     @cacheControl(scope: PRIVATE)

--- a/node/resolvers/directives.ts
+++ b/node/resolvers/directives.ts
@@ -1,6 +1,7 @@
 import { WithSession } from './directives/withSession'
 import { WithPermissions } from './directives/withPermissions'
 import { ValidateAdminUserAccess } from './directives/validateAdminUserAccess'
+import { ValidateStoreUserAccess } from './directives/validateStoreUserAccess'
 import { CheckAdminAccess } from './directives/checkAdminAccess'
 import { CheckUserAccess } from './directives/checkUserAccess'
 import { AuditAccess } from './directives/auditAccess'
@@ -9,6 +10,7 @@ export const schemaDirectives = {
   checkAdminAccess: CheckAdminAccess as any,
   checkUserAccess: CheckUserAccess as any,
   validateAdminUserAccess: ValidateAdminUserAccess as any,
+  validateStoreUserAccess: ValidateStoreUserAccess as any,
   withPermissions: WithPermissions as any,
   withSession: WithSession as any,
   auditAccess: AuditAccess as any,

--- a/node/resolvers/directives/validateStoreUserAccess.ts
+++ b/node/resolvers/directives/validateStoreUserAccess.ts
@@ -1,0 +1,166 @@
+import { SchemaDirectiveVisitor } from 'graphql-tools'
+import { AuthenticationError, ForbiddenError } from '@vtex/api'
+import type { GraphQLField } from 'graphql'
+import { defaultFieldResolver } from 'graphql'
+
+import type { AuthAuditMetric } from '../../utils/metrics/auth'
+import sendAuthMetric, { AuthMetric } from '../../utils/metrics/auth'
+import {
+  validateAdminToken,
+  validateAdminTokenOnHeader,
+  validateApiToken,
+  validateStoreToken,
+} from './helper'
+
+export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
+  public visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field
+
+    field.resolve = async (
+      root: any,
+      args: any,
+      context: Context,
+      info: any
+    ) => {
+      const {
+        vtex: { adminUserAuthToken, storeUserAuthToken, logger },
+      } = context
+
+      // get metrics data
+      const operation = field?.astNode?.name?.value ?? context?.request?.url
+      const userAgent = context?.request?.headers['user-agent'] as string
+      const caller = context?.request?.headers['x-vtex-caller'] as string
+      const forwardedHost = context?.request?.headers[
+        'x-forwarded-host'
+      ] as string
+
+      // set metric fields with initial data
+      let metricFields: AuthAuditMetric = {
+        operation,
+        forwardedHost,
+        caller,
+        userAgent,
+      }
+
+      const { hasAdminToken, hasValidAdminToken } = await validateAdminToken(
+        context,
+        adminUserAuthToken as string
+      )
+
+      // add admin token metrics
+      metricFields = {
+        ...metricFields,
+        hasAdminToken,
+        hasValidAdminToken,
+      }
+
+      // allow access if has valid admin token
+      if (hasValidAdminToken) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateStoreUserAccessAudit'
+          )
+        )
+
+        return resolve(root, args, context, info)
+      }
+
+      // If there's no valid admin token on context, search for it on header
+      const { hasAdminTokenOnHeader, hasValidAdminTokenOnHeader } =
+        await validateAdminTokenOnHeader(context)
+
+      // add admin header token metrics
+      metricFields = {
+        ...metricFields,
+        hasAdminTokenOnHeader,
+        hasValidAdminTokenOnHeader,
+      }
+
+      // allow access if has valid admin token
+      if (hasValidAdminTokenOnHeader) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateStoreUserAccessAudit'
+          )
+        )
+
+        return resolve(root, args, context, info)
+      }
+
+      const { hasApiToken, hasValidApiToken } = await validateApiToken(context)
+
+      // add API token metrics
+      metricFields = {
+        ...metricFields,
+        hasApiToken,
+        hasValidApiToken,
+      }
+
+      // allow access if has valid API token
+      if (hasValidApiToken) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateStoreUserAccessAudit'
+          )
+        )
+
+        return resolve(root, args, context, info)
+      }
+
+      const { hasStoreToken, hasValidStoreToken } = await validateStoreToken(
+        context,
+        storeUserAuthToken as string
+      )
+
+      // add store token metrics
+      metricFields = {
+        ...metricFields,
+        hasStoreToken,
+        hasValidStoreToken,
+      }
+
+      // allow access if has valid store token
+      if (hasValidStoreToken) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateStoreUserAccessAudit'
+          )
+        )
+
+        return resolve(root, args, context, info)
+      }
+
+      // deny access if no tokens were provided
+      if (!hasAdminToken && !hasApiToken && !hasStoreToken) {
+        logger.warn({
+          message: 'ValidateStoreUserAccess: No token provided',
+          ...metricFields,
+        })
+        throw new AuthenticationError('No token was provided')
+      }
+
+      // deny access if no valid tokens were provided
+      logger.warn({
+        message: `ValidateStoreUserAccess: Invalid token`,
+        ...metricFields,
+      })
+      throw new ForbiddenError('Unauthorized Access')
+    }
+  }
+}

--- a/node/utils/metrics/auth.ts
+++ b/node/utils/metrics/auth.ts
@@ -13,6 +13,7 @@ export interface AuthAuditMetric {
   hasAdminToken?: boolean
   hasValidAdminToken?: boolean
   hasStoreToken?: boolean
+  hasCurrentValidStoreToken?: boolean
   hasValidStoreToken?: boolean
   hasApiToken?: boolean
   hasValidApiToken?: boolean


### PR DESCRIPTION
#### What problem is this solving?

Add new store user token validation to getOrganizations and saveUser APIs. See more: https://vtex-dev.atlassian.net/browse/B2BTEAM-1891
