### PR TITLE
Added  Organization Setting "Full Impersonation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.59.0] - 2024-10-08
 ### Added
+
+- `Full Impersonation` Organization Setting, this will allow a Impersonator to also Switch between the User's Organization/Cost Center
+
+## [0.59.0] - 2024-10-08
+
+### Added
+
 - Add permission createQuote to organization
 
 ## [0.58.0] - 2024-10-07
 
 ### Added
+
 - Add new admin token validation directive to getOrganizationsWithoutSalesManager
 
 ## [0.57.1] - 2024-09-30
 
 ### Fixed
+
 - Change GetOrganizationRequests API cache control scope to private
 
 ## [0.57.0] - 2024-09-12
 
 ### Added
+
 - Add new admin token validation directive to some APIs
 
 ## [0.56.2] - 2024-09-10
@@ -35,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.56.1] - 2024-09-10
 
 ### Added
+
 - Add logging for store token validation
 
 ## [0.56.0] - 2024-09-09
@@ -46,6 +56,7 @@ Adds a new `getAccount` query to retrieve account information. It includes field
 ## [0.55.0] - 2024-08-22
 
 ### Added
+
 - Add paymentTerms field to cost center input on mutations
 
 ## [0.54.0] - 2024-08-12

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -524,6 +524,7 @@ type TransactionEmailSettings {
 type UISettings {
   showModal: Boolean
   clearCart: Boolean
+  fullImpersonation: Boolean
 }
 
 scalar Data
@@ -679,6 +680,7 @@ input TransactionEmailSettingsInput {
 input UISettingsInput {
   showModal: Boolean
   clearCart: Boolean
+  fullImpersonation: Boolean
 }
 
 input B2BSettingsInput {

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -234,6 +234,7 @@ interface Price {
 interface UISettings {
   showModal: boolean
   clearCart: boolean
+  fullImpersonation: boolean
 }
 
 interface CustomField {


### PR DESCRIPTION
#### What problem is this solving?
Our client needs to allow Customer support to impersonate a user and be able to switch between the user's Organization.

#### How to test it?
- Head over to [https://wender--kevinyeebiz.myvtex.com/](https://wender--kevinyeebiz.myvtex.com/)
- Add to your admin user access to Call Center Operator
- Now, back to the Home Page, impersonate the user `kevinyee13+salesrepa@gmail.com` (that belongs to more than one organization)
- After reloading, click My Organization; initially, you won't be able to switch to a different Organization
- Now head over to the Organization Admin, Settings tab, Enable and Save "Full Impersonation"
- Head back to the home page and open the My Organization dropdown
- You should now be able to switch

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:
Impersonating
<img width="658" alt="image" src="https://github.com/user-attachments/assets/2864417d-70cf-4606-9e9e-ee0ab864f70a">

My Organization, without Full Impersonation
<img width="522" alt="image" src="https://github.com/user-attachments/assets/a93f0e8e-8106-40ac-a0d4-21c1a7299e23">

Organization Settings
<img width="565" alt="image" src="https://github.com/user-attachments/assets/3286892f-fe0b-4e93-81bf-6700c145b125">


<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->
