### PR TITLE
feat: add topBar settings type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add TopBarSettings type in B2B settings and updated saveB2BSettings to use the new topBar field in UISettings
 
 ## [0.62.0] - 2024-12-03
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -525,10 +525,19 @@ type TransactionEmailSettings {
   organizationStatusChanged: Boolean
 }
 
+type TopBarSettings {
+  name: String
+  hexColor: String
+}
+
 type UISettings {
   showModal: Boolean
   clearCart: Boolean
+<<<<<<< HEAD
   fullImpersonation: Boolean
+=======
+  topBar: TopBarSettings
+>>>>>>> 723475d (feat: add topBar settings type)
 }
 
 scalar Data
@@ -681,10 +690,19 @@ input TransactionEmailSettingsInput {
   organizationStatusChanged: Boolean
 }
 
+input TopBarSettingsInput {
+  name: String
+  hexColor: String
+}
+
 input UISettingsInput {
   showModal: Boolean
   clearCart: Boolean
+<<<<<<< HEAD
   fullImpersonation: Boolean
+=======
+  topBar: TopBarSettingsInput
+>>>>>>> 723475d (feat: add topBar settings type)
 }
 
 input B2BSettingsInput {

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -103,7 +103,11 @@ const Settings = {
         transactionEmailSettings:
           transactionEmailSettings ??
           currentB2BSettings?.transactionEmailSettings,
-        uiSettings,
+        uiSettings: {
+          showModal: uiSettings.showModal,
+          clearCart: uiSettings.clearCart,
+          topBar: uiSettings.topBar ?? currentB2BSettings?.uiSettings?.topBar,
+        },
       }
 
       await vbase.saveJSON(B2B_SETTINGS_DATA_ENTITY, 'settings', b2bSettings)

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -239,10 +239,19 @@ interface Price {
   id: string
 }
 
+interface TopBarSetting {
+  name: string
+  hexColor: string
+}
+
 interface UISettings {
   showModal: boolean
   clearCart: boolean
+<<<<<<< HEAD
   fullImpersonation: boolean
+=======
+  topBar?: TopBarSetting | null
+>>>>>>> 723475d (feat: add topBar settings type)
 }
 
 interface CustomField {


### PR DESCRIPTION
#### What problem is this solving?

This change allows customization of the top bar appearance (name and color) in B2B settings.

#### How to test it?


Get:
![image](https://github.com/user-attachments/assets/54b5e69a-9458-460c-b504-4201d83d5bbd)
```
{
  getB2BSettings {
    uiSettings {
      showModal
      clearCart
      topBar {
        name
        hexColor
      }
    }
  }
}
```

Insert:
![image](https://github.com/user-attachments/assets/34f54f10-040d-457f-9fb9-d4f2e4a99342)
```
mutation {
  saveB2BSettings(
    input: {
      uiSettings: {
        showModal: true
        clearCart: false
        topBar: {
          name: "Top Bar Example"
          hexColor: "#FF5733"
        }
      }
    }
  ) {
    status
  }
}
```

https://guidobernal--b2bstore005.myvtex.com/admin/graphql-ide

#### Screenshots or example usage:

As it's just a type addition, there is no concrete usage example. Testing can be done through schema verification.

#### Describe alternatives you've considered, if any.

No alternatives.

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

:)
