### PR TITLE
feat: added tradename and id on org search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `tradeName` and `id` to organization search on getOrganizations and getOrganizationRequests queries
+
 ## [0.61.0] - 2024-10-16
 
 ### Added

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -15,7 +15,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'sellers',
   'customFields',
 ]
-export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.1'
+export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.2'
 
 export const ORGANIZATION_DATA_ENTITY = 'organizations'
 export const ORGANIZATION_FIELDS = [
@@ -33,7 +33,7 @@ export const ORGANIZATION_FIELDS = [
   'customFields',
   'permissions',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.8'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.9'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -112,7 +112,14 @@ export const schemas = [
           title: 'Custom Fields',
         },
       },
-      'v-indexed': ['name', 'b2bCustomerAdmin', 'status', 'created'],
+      'v-indexed': [
+        'id',
+        'tradeName',
+        'name',
+        'b2bCustomerAdmin',
+        'status',
+        'created',
+      ],
       'v-immediate-indexing': true,
       'v-cache': false,
     },
@@ -177,7 +184,7 @@ export const schemas = [
           },
         },
       },
-      'v-indexed': ['name', 'status', 'created'],
+      'v-indexed': ['id', 'tradeName', 'name', 'status', 'created'],
       'v-immediate-indexing': true,
       'v-cache': false,
     },

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -138,7 +138,9 @@ const Organizations = {
     const whereArray = getWhereByStatus({ status })
 
     if (search) {
-      whereArray.push(`name="*${search}*"`)
+      whereArray.push(
+        `(name="*${search}*" OR tradeName="*${search}*" OR id="*${search}*")`
+      )
     }
 
     const where = whereArray.join(' AND ')
@@ -383,7 +385,9 @@ const Organizations = {
       if (search.match(/[a-z\d]+@[a-z]+\.[a-z]{2,3}/gm)) {
         whereArray.push(`b2bCustomerAdmin.email=${search}`)
       } else {
-        whereArray.push(`name="*${search}*"`)
+        whereArray.push(
+          `(name="*${search}*" OR tradeName="*${search}*" OR id="*${search}*")`
+        )
       }
     }
 


### PR DESCRIPTION
#### What problem is this solving?
- Allow search by trade name (open PR).
- Allow search by Organization ID.

<!--- What is the motivation and context for this change? -->

#### How to test it?

Make a post request to this url: https://giurigaud--b2bstore005.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.51.0/graphiql/v1?
Use a query like this:
`{"query":"query{\n  getOrganizations(search: \"15672\" ){\n    data {\n      id\n      name\n    }\n    pagination {\n      page\n      pageSize\n      total\n    }\n  }\n}\n\n# query{\n#   getCostCenters{\n#     data{\n#       id\n#       name\n#       organization\n#       businessDocument\n#     }\n#   }\n# }","variables":null}`
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://giurigaud--b2bstore005.myvtex.com/!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmduaW1zN3B4MWF3eWV2ajd1YXF5ajdkZ3dmaHBycXFpMDU1bDNuMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/YnBntKOgnUSBkV7bQH/giphy.gif)

