### PR TITLE
fix: [KI 1092989] getOrganizationsByEmail to return only active organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add getActiveOrganizationsByEmail to return only active organizations
 
 ## [0.61.1] - 2024-10-29
 
 ### Fixed
 - Avoid calls to checkUserPermissions when session data is not available
+
 
 ## [0.61.0] - 2024-10-16
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -96,6 +96,7 @@ type Query {
   getActiveOrganizationsByEmail(email: String): [B2BOrganization]
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
+    @validateStoreUserAccess
 
   checkOrganizationIsActive(id: String): Boolean
     @cacheControl(scope: PRIVATE)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -93,6 +93,10 @@ type Query {
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
 
+  getActiveOrganizationsByEmail(email: String): [B2BOrganization]
+    @checkUserAccess
+    @cacheControl(scope: PRIVATE)
+
   checkOrganizationIsActive(id: String): Boolean
     @cacheControl(scope: PRIVATE)
     @auditAccess

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -94,7 +94,6 @@ type Query {
     @cacheControl(scope: PRIVATE)
 
   getActiveOrganizationsByEmail(email: String): [B2BOrganization]
-    @checkUserAccess
     @cacheControl(scope: PRIVATE)
     @validateStoreUserAccess
 

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
   "version": "0.61.1",
   "dependencies": {
     "@types/lodash": "4.14.74",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -7,13 +7,19 @@ import {
   ORGANIZATION_REQUEST_SCHEMA_VERSION,
   ORGANIZATION_SCHEMA_VERSION,
 } from '../../mdSchema'
-import type {
-  GetOrganizationsByEmailWithStatus,
-  Organization,
-} from '../../typings'
+import type { Organization } from '../../typings'
 import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import checkConfig from '../config'
 import { organizationStatus } from '../fieldResolvers'
+
+export interface GetOrganizationsByEmailWithStatus {
+  costId: string
+  orgId: string
+  roleId: string
+  id: string
+  clId: string
+  status: string
+}
 
 const getWhereByStatus = ({ status }: { status: string[] }) => {
   const whereArray = []
@@ -265,6 +271,32 @@ const Organizations = {
           : true)
       )
     })
+
+    try {
+      return organizations
+    } catch (error) {
+      logger.error({
+        error,
+        message: 'getOrganizationsByEmail-error',
+      })
+      throw new GraphQLError(getErrorMessage(error))
+    }
+  },
+
+  getActiveOrganizationsByEmail: async (
+    _: void,
+    { email }: { email: string },
+    ctx: Context
+  ) => {
+    const {
+      vtex: { logger },
+    } = ctx
+
+    const organizations = await Organizations.getOrganizationsByEmail(
+      _,
+      { email },
+      ctx
+    )
 
     const organizationsWithStatus: GetOrganizationsByEmailWithStatus[] =
       await Promise.all(

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import {
   ORGANIZATION_DATA_ENTITY,
   ORGANIZATION_FIELDS,
@@ -7,19 +6,13 @@ import {
   ORGANIZATION_REQUEST_SCHEMA_VERSION,
   ORGANIZATION_SCHEMA_VERSION,
 } from '../../mdSchema'
-import type { Organization } from '../../typings'
+import type {
+  GetOrganizationsByEmailWithStatus,
+  Organization,
+} from '../../typings'
 import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
 import checkConfig from '../config'
 import { organizationStatus } from '../fieldResolvers'
-
-export interface GetOrganizationsByEmailWithStatus {
-  costId: string
-  orgId: string
-  roleId: string
-  id: string
-  clId: string
-  status: string
-}
 
 const getWhereByStatus = ({ status }: { status: string[] }) => {
   const whereArray = []
@@ -320,7 +313,7 @@ const Organizations = {
     } catch (error) {
       logger.error({
         error,
-        message: 'getOrganizationsByEmail-error',
+        message: 'getActiveOrganizationsByEmail-error',
       })
       throw new GraphQLError(getErrorMessage(error))
     }

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -167,6 +167,14 @@ interface Collection {
   id: string
   name: string
 }
+interface GetOrganizationsByEmailWithStatus {
+  costId: string
+  orgId: string
+  roleId: string
+  id: string
+  clId: string
+  status: string
+}
 
 interface CostCenter {
   id: string

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -163,6 +163,15 @@ interface Organization {
   sellers?: Seller[]
 }
 
+export type GetOrganizationsByEmailWithStatus = {
+  costId: string
+  orgId: string
+  roleId: string
+  id: string
+  clId: string
+  status: string
+}
+
 interface Collection {
   id: string
   name: string

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -163,15 +163,6 @@ interface Organization {
   sellers?: Seller[]
 }
 
-export type GetOrganizationsByEmailWithStatus = {
-  costId: string
-  orgId: string
-  roleId: string
-  id: string
-  clId: string
-  status: string
-}
-
 interface Collection {
   id: string
   name: string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -836,10 +836,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -3475,7 +3475,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Inactive organizations shown when changing organizations<!--- What is the motivation and context for this change? -->

#### How to test it?

- Register at least two organizations with the same email;
- Inactivate an organization;
- Enter the store and change the organization; the inactive organization can't be shown in the list.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://giurigaud--b2bstore005.myvtex.com/)

#### Screenshots or example usage:

Before change:
<img width="1104" alt="KI 1092989  Before" src="https://github.com/user-attachments/assets/3a062d77-9abb-4fbe-983c-75759ee9cc58">

After change:
<img width="1104" alt="Screenshot 2024-10-18 at 12 23 14" src="https://github.com/user-attachments/assets/d42d29a9-fc69-482d-9f47-6ebb86416202">

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://giphy.com/gifs/theoffice-the-office-tv-moroccan-christmas-cXblnKXr2BQOaYnTni)
