### PR TITLE
feat: add documento to getOrganizations query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `document` field to `getOrganizations` query
+
 ## [0.61.0] - 2024-10-16
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -18,6 +18,7 @@ type Query {
   getOrganizations(
     status: [String]
     search: String
+    document: String
     page: Int = 1
     pageSize: Int = 25
     sortOrder: String = "ASC"


### PR DESCRIPTION
#### What problem is this solving?

Allow search by Cost Center Document on getOrganizations query.

<!--- What is the motivation and context for this change? -->

#### How to test it?

Make a post request to this url: https://giurigaud--b2bstore005.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.51.0/graphiql/v1?
Use a query like this:
{"query":"query{\n  getOrganizations(document: \"15672\" ){\n    data {\n      id\n      name\n    }\n    pagination {\n      page\n      pageSize\n      total\n    }\n  }\n}\n\n# query{\n#   getCostCenters{\n#     data{\n#       id\n#       name\n#       organization\n#       businessDocument\n#     }\n#   }\n# }","variables":null}


<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace]([Workspace](https://giurigaud--b2bstore005.myvtex.com/!))

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on
https://github.com/vtex-apps/b2b-organizations-graphql/pull/183
<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
