### PR TITLE
fix: check user permission error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
 - Avoid calls to checkUserPermissions when session data is not available
 
 ## [0.61.0] - 2024-10-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Avoid calls to checkUserPermissions when session data is not available
 
 ## [0.61.0] - 2024-10-16
 

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -313,22 +313,26 @@ const costCenters = {
       throw new Error('This organization is not active')
     }
 
-    const {
-      data: { checkUserPermission },
-    }: any = await storefrontPermissions
-      .checkUserPermission('vtex.b2b-organizations@1.x')
-      .catch((error: any) => {
-        logger.error({
-          error,
-          message: 'checkUserPermission-error',
+    let checkUserPermission = null
+
+    if (sessionData?.namespaces) {
+      const checkUserPermissionResult = await storefrontPermissions
+        .checkUserPermission('vtex.b2b-organizations@1.x')
+        .catch((error: any) => {
+          logger.error({
+            error,
+            message: 'checkUserPermission-error',
+          })
+
+          return {
+            data: {
+              checkUserPermission: null,
+            },
+          }
         })
 
-        return {
-          data: {
-            checkUserPermission: null,
-          },
-        }
-      })
+      checkUserPermission = checkUserPermissionResult?.data?.checkUserPermission
+    }
 
     const isSalesAdmin = checkUserPermission?.role.slug.match(/sales-admin/)
 

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -238,9 +238,23 @@ const Users = {
     ctx: Context
   ) => {
     const {
-      clients: { storefrontPermissions, masterdata },
-      vtex: { adminUserAuthToken, logger, sessionData },
-    } = ctx as any
+      clients: { storefrontPermissions, session, masterdata },
+      vtex: { adminUserAuthToken, logger, sessionToken },
+    } = ctx
+
+    const sessionData = await session
+      .getSession(sessionToken as string, ['*'])
+      .then((currentSession: any) => {
+        return currentSession.sessionData
+      })
+      .catch((error: any) => {
+        logger.warn({
+          error,
+          message: 'getOrganizationsByEmail-session-error',
+        })
+
+        return null
+      })
 
     let checkUserPermission = null
 

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -122,10 +122,15 @@ const checkUserPermissions = async ({
   logger,
 }: any) => {
   const { sessionData } = vtex
-  const { checkUserPermission } = await getCheckUserPermission({
-    logger,
-    storefrontPermissions,
-  })
+
+  let checkUserPermission = null
+
+  if (sessionData?.namespaces) {
+    checkUserPermission = await getCheckUserPermission({
+      logger,
+      storefrontPermissions,
+    })
+  }
 
   const condition = validateUserAdmin
     ? !adminUserAuthToken && !isSalesAdmin(checkUserPermission)
@@ -234,13 +239,17 @@ const Users = {
   ) => {
     const {
       clients: { storefrontPermissions, masterdata },
-      vtex: { adminUserAuthToken, logger },
-    } = ctx
+      vtex: { adminUserAuthToken, logger, sessionData },
+    } = ctx as any
 
-    const { checkUserPermission } = await getCheckUserPermission({
-      logger,
-      storefrontPermissions,
-    })
+    let checkUserPermission = null
+
+    if (sessionData?.namespaces) {
+      checkUserPermission = await getCheckUserPermission({
+        logger,
+        storefrontPermissions,
+      })
+    }
 
     if (!adminUserAuthToken && !isSalesAdmin(checkUserPermission)) {
       throw new GraphQLError('operation-not-permitted')
@@ -252,7 +261,7 @@ const Users = {
       .then((result: any) => {
         return result.data.listAllUsers
       })
-      .catch((error) => {
+      .catch((error: any) => {
         logger.error({
           error,
           message: 'getOrganizationsWithoutSalesManager-getUsers-error',

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -250,7 +250,7 @@ const Users = {
       .catch((error: any) => {
         logger.warn({
           error,
-          message: 'getOrganizationsByEmail-session-error',
+          message: 'getOrganizationsWithoutSalesManager-session-error',
         })
 
         return null

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -35,23 +35,27 @@ const getUserAndPermissions = async (ctx: Context) => {
     throw new ForbiddenError('Access denied')
   }
 
-  const {
-    data: { checkUserPermission },
-  }: any = await storefrontPermissions
-    // It is necessary to send the app name, because the check user return the permissions relative to orders-history to access the page.
-    .checkUserPermission('vtex.b2b-orders-history@0.x')
-    .catch((error: any) => {
-      logger.error({
-        message: 'checkUserPermission-error',
-        error,
+  let checkUserPermission = null
+
+  if (sessionData?.namespaces) {
+    const checkUserPermissionResult = await storefrontPermissions
+      // It is necessary to send the app name, because the check user return the permissions relative to orders-history to access the page.
+      .checkUserPermission('vtex.b2b-orders-history@0.x')
+      .catch((error: any) => {
+        logger.error({
+          message: 'checkUserPermission-error',
+          error,
+        })
+
+        return {
+          data: {
+            checkUserPermission: null,
+          },
+        }
       })
 
-      return {
-        data: {
-          checkUserPermission: null,
-        },
-      }
-    })
+    checkUserPermission = checkUserPermissionResult?.data?.checkUserPermission
+  }
 
   const organizationId =
     sessionData?.namespaces['storefront-permissions']?.organization?.value


### PR DESCRIPTION
#### What problem is this solving?
This fix adds the behavior of avoiding the call of the `checkUserPermission` API of `storefront-permissions` when session data is not available. 

This API uses session data to get the user permissions, so any call without such data would result in an error in `storefront-permissions` (and consequently another one in `b2b-organizations-graphql`) and a `null` result. For this reason, it is not an issue to assume beforehand that the API call will return `null` when the session data is already empty.

Therefore, by avoiding this call when the session data is already known to be empty, the errors won't happen and an unnecessary call between apps will be prevented. The goal is to reduce the amount of error logs in both apps. More details on [https://vtex-dev.atlassian.net/browse/B2BTEAM-1689](https://vtex-dev.atlassian.net/browse/B2BTEAM-1689).
