### PR TITLE
Mail notification to createOrganizationAndCostCenterWithAdminUser Mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added mail notification to `createOrganizationAndCostCenterWithAdminUser` mutation
+
 ## [0.61.1] - 2024-10-29
 
 ### Fixed

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -202,7 +202,7 @@ const createOrganizationAndCostCenterWithAdminUser = async (
   ctx: Context
 ) => {
   const {
-    clients: { storefrontPermissions },
+    clients: { storefrontPermissions, mail },
     vtex: { logger },
   } = ctx
 
@@ -306,6 +306,12 @@ const createOrganizationAndCostCenterWithAdminUser = async (
         storefrontPermissions,
       })
     }
+
+    message({
+      logger,
+      mail,
+      storefrontPermissions,
+    }).organizationCreated(organizationInput.name)
 
     return {
       href: createOrganizationResult.Href,

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -9,14 +9,14 @@ import {
 } from '../../mdSchema'
 import type {
   B2BSettingsInput,
+  Collection,
   DefaultCostCenterInput,
+  NormalizedOrganizationInput,
   Organization,
   OrganizationInput,
-  NormalizedOrganizationInput,
   OrganizationRequest,
   PaymentTerm,
   Price,
-  Collection,
 } from '../../typings'
 import {
   ORGANIZATION_REQUEST_STATUSES,
@@ -246,6 +246,12 @@ const createOrganizationAndCostCenterWithAdminUser = async (
     const { defaultCostCenter, costCenters } = organization
     const { email, firstName, lastName } = organization.b2bCustomerAdmin
 
+    const settings = (await B2BSettings.getB2BSettings(
+      undefined,
+      undefined,
+      ctx
+    )) as B2BSettingsInput
+
     if (costCenters?.length) {
       await Promise.all(
         costCenters?.map(async (costCenter: DefaultCostCenterInput) => {
@@ -307,17 +313,13 @@ const createOrganizationAndCostCenterWithAdminUser = async (
       })
     }
 
-if(settings?.transactionEmailSettings?.organizationCreated) {
-    message({
-          logger,
-          mail,
-      storefrontPermissions,
-    }).organizationCreated(organizationInput.name)
-}
-      logger,
-      mail,
-      storefrontPermissions,
-    }).organizationCreated(organizationInput.name)
+    if (settings?.transactionEmailSettings?.organizationCreated) {
+      message({
+        logger,
+        mail,
+        storefrontPermissions,
+      }).organizationCreated(organizationInput.name)
+    }
 
     return {
       href: createOrganizationResult.Href,

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -307,7 +307,13 @@ const createOrganizationAndCostCenterWithAdminUser = async (
       })
     }
 
+if(settings?.transactionEmailSettings?.organizationCreated) {
     message({
+          logger,
+          mail,
+      storefrontPermissions,
+    }).organizationCreated(organizationInput.name)
+}
       logger,
       mail,
       storefrontPermissions,


### PR DESCRIPTION
#### What problem is this solving?

There is no mail notification to `createOrganizationAndCostCenterWithAdminUser` mutation

It was added to that to keep the same behavior as others.

#### How to test it?

https://mail1--b2bstoreqa.myvtex.com/
