### PR TITLE
feat: creates paginated organizations query

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -93,6 +93,12 @@ type Query {
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
 
+  getOrganizationsPaginatedByEmail(
+    email: String
+    page: Int = 1
+    pageSize: Int = 25
+  ): B2BOrganizationPaginated @checkUserAccess @cacheControl(scope: PRIVATE)
+
   checkOrganizationIsActive(id: String): Boolean
     @cacheControl(scope: PRIVATE)
     @auditAccess
@@ -484,6 +490,11 @@ type B2BOrganization {
   organizationName: String
   organizationStatus: String
   costCenterName: String
+}
+
+type B2BOrganizationPaginated {
+  data: [B2BOrganization]
+  pagination: Pagination
 }
 
 type SimpleRole {

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -8,6 +8,7 @@ import saveUser from '../mutations/saveUser'
 import updateUser from '../mutations/updateUser'
 import getB2BUser from '../queries/getB2BUser'
 import getOrganizationsByEmail from '../queries/getOrganizationsByEmail'
+import getOrganizationsPaginatedByEmail from '../queries/getOrganizationsPaginatedByEmail'
 import getPermission from '../queries/getPermission'
 import getRole from '../queries/getRole'
 import getUser from '../queries/getUser'
@@ -36,6 +37,22 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       query: getOrganizationsByEmail,
       variables: {
         email,
+      },
+    })
+  }
+
+  public getOrganizationsPaginatedByEmail = async (
+    email: string,
+    page: number,
+    pageSize: number
+  ): Promise<any> => {
+    return this.query({
+      extensions: this.getPersistedQuery(),
+      query: getOrganizationsPaginatedByEmail,
+      variables: {
+        email,
+        page,
+        pageSize,
       },
     })
   }

--- a/node/queries/getOrganizationsPaginatedByEmail.ts
+++ b/node/queries/getOrganizationsPaginatedByEmail.ts
@@ -1,0 +1,25 @@
+import { print } from 'graphql'
+import gql from 'graphql-tag'
+
+export default print(gql`
+  query OrganizationsPaginated($email: String!, $page: Int, $pageSize: Int) {
+    getOrganizationsPaginatedByEmail(
+      email: $email
+      page: $page
+      pageSize: $pageSize
+    ) {
+      data {
+        costId
+        orgId
+        roleId
+        id
+        clId
+      }
+      pagination {
+        page
+        pageSize
+        total
+      }
+    }
+  }
+`)

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -270,6 +270,111 @@ const Organizations = {
     }
   },
 
+  getOrganizationsPaginatedByEmail: async (
+    _: void,
+    {
+      email,
+      page = 1,
+      pageSize = 25,
+    }: {
+      email?: string
+      page: number
+      pageSize: number
+    },
+    {
+      clients: { storefrontPermissions, session },
+      vtex: { logger, sessionToken, adminUserAuthToken },
+    }: any
+  ) => {
+    const organizationFilters: string[] = []
+    let fromSession = false
+    const {
+      data: { checkUserPermission },
+    }: any = await storefrontPermissions
+      .checkUserPermission('vtex.b2b-organizations@1.x')
+      .catch((error: any) => {
+        logger.error({
+          error,
+          message: 'checkUserPermission-error',
+        })
+
+        return {
+          data: {
+            checkUserPermission: null,
+          },
+        }
+      })
+
+    if (
+      (!adminUserAuthToken &&
+        !checkUserPermission?.permissions.includes('add-sales-users-all')) ||
+      !email?.length
+    ) {
+      const sessionData = await session
+        .getSession(sessionToken as string, ['*'])
+        .then((currentSession: any) => {
+          return currentSession.sessionData
+        })
+        .catch((error: any) => {
+          logger.warn({
+            error,
+            message: 'getOrganizationsPaginatedByEmail-session-error',
+          })
+
+          return null
+        })
+
+      if (checkUserPermission?.permissions.includes('add-users-organization')) {
+        const orgId =
+          sessionData?.namespaces?.['storefront-permissions']?.organization
+            ?.value
+
+        if (!orgId) {
+          throw new Error('No permission for getting the organizations')
+        }
+
+        organizationFilters.push(orgId)
+      }
+
+      if (!email?.length) {
+        email = sessionData?.namespaces?.profile?.email?.value
+        fromSession = true
+      }
+    }
+
+    const response =
+      await storefrontPermissions.getOrganizationsPaginatedByEmail(
+        email,
+        page,
+        pageSize
+      )
+
+    const organizations =
+      response?.data?.getOrganizationsPaginatedByEmail?.data?.filter(
+        ({ orgId }: { orgId: string }) => {
+          return (
+            fromSession ||
+            (organizationFilters.length > 0
+              ? organizationFilters.find((id: string) => orgId === id)
+              : true)
+          )
+        }
+      )
+
+    try {
+      return {
+        data: organizations,
+        pagination: response.data?.getOrganizationsPaginatedByEmail?.pagination,
+      }
+    } catch (error) {
+      logger.error({
+        error,
+        message: 'getOrganizationsPaginatedByEmail-error',
+      })
+      throw new GraphQLError(getErrorMessage(error))
+    }
+  },
+
   getOrganizationByIdStorefront: async (
     _: void,
     { id }: { id: string },


### PR DESCRIPTION
**What problem is this solving?**

This update optimizes the retrieval of organizations and cost center information by implementing paginated queries instead of fetching all data at once. It prevents timeouts and improves performance when users are associated with a large number of organizations.

ClickUp: https://app.clickup.com/t/868amdqqw

**How should this be manually tested?**

1. Test with an email associated with a small number of organizations to ensure correct data retrieval.
2. Test with an email linked to a large number of organizations to verify that pagination works correctly and avoids timeouts.
3. Confirm that:
   - A valid `costId` is returned if a cost center is available.
   - An organization with a status other than `inactive` is retrieved correctly.
   - Proper null responses occur when no valid data is found.
4. Use edge cases, such as emails with no associated organizations, to confirm behavior. 

**Screenshots or example usage:**

![image](https://github.com/user-attachments/assets/86adc939-ec77-4df8-a69e-807c30d3aa20)

`{
  getOrganizationsPaginatedByEmail(email: "", page: 1, pageSize: 25) {
    data {
      id
      clId
      costId
      orgId
      organizationName
      costCenterName
    }
    pagination {
      page
      pageSize
      total
    }
  }
}
`

storefront-permissions PR: https://github.com/vtex-apps/storefront-permissions/pull/172
