### PR TITLE
Fix/uisettings validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.63.1] - 2024-12-10
 ### Fixed
 - Fix `saveB2BSettings` mutation when `uiSettings` is absent
 
+## [0.63.1] - 2024-12-10
 ### Added
 
 - Added mail notification to `createOrganizationAndCostCenterWithAdminUser` mutation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [0.63.1] - 2024-12-10
+### Fixed
+- Fix `saveB2BSettings` mutation when `uiSettings` is absent
 
 ### Added
 

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -104,9 +104,11 @@ const Settings = {
           transactionEmailSettings ??
           currentB2BSettings?.transactionEmailSettings,
         uiSettings: {
-          showModal: uiSettings.showModal,
-          clearCart: uiSettings.clearCart,
-          topBar: uiSettings.topBar ?? currentB2BSettings?.uiSettings?.topBar,
+          showModal:
+            uiSettings?.showModal ?? currentB2BSettings?.uiSettings.showModal,
+          clearCart:
+            uiSettings?.clearCart ?? currentB2BSettings?.uiSettings.clearCart,
+          topBar: uiSettings?.topBar ?? currentB2BSettings?.uiSettings?.topBar,
         },
       }
 


### PR DESCRIPTION
#### What problem is this solving?

Fix validation for when the mutation is sent without the uiSettings object 

#### How to test it?

Run the mutation without the uiSettings object in prod and with these changes. In prod it will break, with these changes it will work fine.

```
mutation {
  saveB2BSettings(
    input: {
      autoApprove: false,
    }
  ) {
    status
  }
}
```


[Workspace](https://everton--b2bstore005.myvtex.com/_v/private/vtex.b2b-organizations-graphql@0.63.1/graphiql/v1?query=mutation%20%7B%0A%20%20saveB2BSettings(%0A%20%20%20%20input%3A%20%7B%0A%20%20%20%20%20%20autoApprove%3A%20false%2C%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20status%0A%20%20%7D%0A%7D)
