### PR TITLE
Fix return removeUserWithEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix return from `removeUserWithEmail`
 
 ## [0.63.2] - 2024-12-19
 ### Fixed

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -378,12 +378,15 @@ const Users = {
       vtex: { logger },
     } = ctx as any
 
-    storefrontPermissionsClient
+    return storefrontPermissionsClient
       .getUsersByEmail(email, orgId, costId)
       .then((result: any) => {
         const user = result.data.getUsersByEmail[0]
 
-        if (!user) return
+        if (!user) {
+          logger.error({ message: 'User not found' })
+          return { status: 'error', message: 'User not found' }
+        }
 
         const { id } = user
         const { userId } = user


### PR DESCRIPTION
#### What problem is this solving?

Empty return when using the mutation `removeUsersWithEmail`

#### How to test it?

[Workspace](https://deleteuser--b2bstore005.myvtex.com/admin)

#### Screenshots or example usage:

Before
![image](https://github.com/user-attachments/assets/77c31a99-be24-4b87-85cb-ef559bd248cc)

After
![image](https://github.com/user-attachments/assets/d40a9e14-5907-45ce-9d99-3c917017610d)