### PR TITLE
Added `notes` when updating organization requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `notes` when updating organization request document
 
 ## [0.63.2] - 2024-12-19
 ### Fixed

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -812,7 +812,7 @@ const Organizations = {
 
           await masterdata.updatePartialDocument({
             dataEntity: ORGANIZATION_REQUEST_DATA_ENTITY,
-            fields: { status },
+            fields: { status, notes },
             id,
           })
 


### PR DESCRIPTION
#### What problem is this solving?

Adding `notes` when updating organization requests

#### How to test it?

Create a organization request, and check the notes after, it'll be "Auto approved"

[Workspace](https://tkt1197323--b2bstore005.myvtex.com/organization-request)
