### PR TITLE
Set parameters in saveB2BSettings mutation as optional

### DIFF
--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -105,9 +105,9 @@ const Settings = {
           currentB2BSettings?.transactionEmailSettings,
         uiSettings: {
           showModal:
-            uiSettings?.showModal ?? currentB2BSettings?.uiSettings.showModal,
+            uiSettings?.showModal ?? currentB2BSettings?.uiSettings?.showModal,
           clearCart:
-            uiSettings?.clearCart ?? currentB2BSettings?.uiSettings.clearCart,
+            uiSettings?.clearCart ?? currentB2BSettings?.uiSettings?.clearCart,
           topBar: uiSettings?.topBar ?? currentB2BSettings?.uiSettings?.topBar,
         },
       }


### PR DESCRIPTION
## What problem is this solving?

The "saveB2BSettings" mutation first save the current configurations object to use it as a fallback for parameters that are not sent in the mutation to ensure compatibility.

In cases where "currentB2BSettings.uiSettings: null" an error is thrown due to not being able to read "currentB2BSettings.uiSettings.showModal". An example is when trying to create a new custom field.

![image](https://github.com/user-attachments/assets/c3f50fdc-5b6f-4de1-92f2-8938410ab854)

This fix sets the field "currentB2BSettings.uiSettings" as optional and, for cases where it is "null", no reading error is thrown.

## How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

In a B2B Store where the configurations for "uiSettings: null" try to create a new CustomField. 

[Workspace](https://savesettings--b2bstore005.myvtex.com/admin/b2b-organizations/organizations#/custom-fields)

## Screenshots or example usage:

After the fix when using the mutation "saveB2BSettings" in for a store where "uiSettings: null" the fields are correctly assigned as null, avoiding the exception.

![image](https://github.com/user-attachments/assets/a3cd1e6c-1304-47f7-8e87-b0f408cb9731)
