### PR TITLE
fix: update patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Generating new patch version
+
 ## [1.0.0] - 2025-05-27
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

As version 1.0.0 already existed and was deprecated, we need to generate a new patch version.
This is an empty commit just to generate version 1.0.1

