### PR TITLE
fix: invalidate admin token if invalid token is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Invalidate admin token if an invalid token is provided
+
 ## [1.0.1] - 2025-05-27
 
 ### Fixed

--- a/node/resolvers/directives/validateAdminUserAccess.ts
+++ b/node/resolvers/directives/validateAdminUserAccess.ts
@@ -81,6 +81,8 @@ export class ValidateAdminUserAccess extends SchemaDirectiveVisitor {
 
       // allow access if has valid admin token
       if (hasValidAdminTokenOnHeader) {
+        // set adminUserAuthToken on context so it can be used later
+        context.vtex.adminUserAuthToken = context?.headers.vtexidclientautcookie as string
         sendAuthMetric(
           context,
           logger,

--- a/node/resolvers/directives/validateStoreUserAccess.ts
+++ b/node/resolvers/directives/validateStoreUserAccess.ts
@@ -82,6 +82,8 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
 
       // allow access if has valid admin token
       if (hasValidAdminTokenOnHeader) {
+        // set adminUserAuthToken on context so it can be used later
+        context.vtex.adminUserAuthToken = context?.headers.vtexidclientautcookie as string
         sendAuthMetric(
           context,
           logger,
@@ -94,6 +96,10 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
 
         return resolve(root, args, context, info)
       }
+
+      // If there's no valid admin token on context or header,
+      // invalidate the adminUserAuthToken on context
+      context.vtex.adminUserAuthToken = undefined
 
       const { hasApiToken, hasValidApiToken } = await validateApiToken(context)
 


### PR DESCRIPTION
#### What problem is this solving?

Improve token handling by Invalidating admin token if an invalid token is provided.
