### PR TITLE
fix: allow GetOrganizationRequestById to receive cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed GetOrganizationRequestById cache control, allowing auth cookies to be sent
+
 ## [1.0.2] - 2025-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Fixed GetOrganizationRequestById cache control, allowing auth cookies to be sent
+- Changed getOrganizationRequestById and getCostCenters cache control to private, allowing auth cookies to be sent
 
 ## [1.0.2] - 2025-06-16
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -13,7 +13,7 @@ type Query {
     @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @validateAdminUserAccess
   getOrganizationRequestById(id: ID!): OrganizationRequest
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @validateAdminUserAccess
   getOrganizations(
     status: [String]
@@ -44,7 +44,7 @@ type Query {
     sortOrder: String = "ASC"
     sortedBy: String = "name"
   ): CostCenterResult
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PRIVATE, maxAge: SHORT)
     @validateStoreUserAccess
   getCostCentersByOrganizationId(
     id: ID


### PR DESCRIPTION
#### What problem is this solving?

`getOrganizationRequestById` requests were failing with `No auth cookie provided`.
This is because the cache control for this API was set to `PUBLIC`.
This PR changes the cache control for this API to `PRIVATE`. It also fixes the same thing for the `getCostCenters` APIs (that are less used, but would suffer from the same issue).