### PR TITLE
feat: add user email to order cancellation reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-09-05
+### Added
+- Add user email to order cancellation reason
+
 ## [1.0.3] - 2025-07-23
 
 ### Fixed

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -6,10 +6,13 @@ export default class Checkout extends JanusClient {
     super(ctx, { ...options })
   }
 
-  public async requestCancellation(orderId: string) {
+  public async requestCancellation(
+    orderId: string,
+    reason: string
+  ) {
     return this.http.postRaw(
       `${this.routes.requestCancellation(orderId)}`,
-      {},
+      {reason},
       {
         headers: {
           VtexIdclientAutCookie: this.context.authToken,

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -314,8 +314,11 @@ const Index = {
       throw new ForbiddenError('Access denied')
     }
 
+    const reason = `order canceled by user: ${authEmail}`
+
     const requestCancellationResponse = await checkout.requestCancellation(
-      orderId as string
+      orderId as string,
+      reason as string
     )
 
     ctx.set('Content-Type', 'application/json')


### PR DESCRIPTION
#### What problem is this solving?

Added the reason field to the order cancellation request to indicate that the cancellation was performed by the user, along with the user who executed the cancellation.