### PR TITLE
Feature/audit mutations queries

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -82,6 +82,13 @@
         "host": "rc.vtex.com",
         "path": "/api/analytics/schemaless-events"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "analytics.vtex.com",
+        "path": "*"
+      }
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/audit.ts
+++ b/node/clients/audit.ts
@@ -1,0 +1,55 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { ExternalClient } from '@vtex/api'
+
+export class AuditClient extends ExternalClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super('http://analytics.vtex.com', ctx, {
+      ...options,
+      headers: {
+        'Proxy-Authorization': ctx.adminUserAuthToken || '',
+        VtexIdClientAutCookie: ctx.adminUserAuthToken || '',
+        Authorization: ctx.authToken,
+        'X-Vtex-Use-Https': 'true',
+      },
+    })
+  }
+
+  public async sendEvent(
+    auditEntry: AuditEntry,
+    sessionMeta: any
+  ): Promise<void> {
+    console.log('sendEvent', auditEntry)
+    const { meta, subjectId, operation, authorId } = auditEntry
+    const { account, operationId, requestId, userAgent, logger } = this.context
+
+    console.log('sendEvent account', account)
+
+    const auditEvent = {
+      mainAccountName: account,
+      accountName: account,
+      id: requestId,
+      subjectId,
+      authorId,
+      application: 'vtex.b2b-organizations-graphql',
+      operation,
+      operationId,
+      meta: {
+        fowardFromVtexUserAgent: userAgent,
+        ...meta,
+      },
+      date: new Date().toJSON(),
+    }
+
+    console.log('auditEvent', auditEvent)
+
+    try {
+      await this.http.post(
+        `http://analytics.vtex.com/api/audit/events?an=${account}`,
+        auditEvent
+      )
+    } catch (error) {
+      console.log(sessionMeta, logger)
+      console.log('error ------', error)
+    }
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -12,11 +12,16 @@ import StorefrontPermissions from './storefrontPermissions'
 import IdentityClient from './IdentityClient'
 import Catalog from './catalog'
 import SellersClient from './sellers'
+import { AuditClient } from './audit'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
   public get lm() {
     return this.getOrSet('lm', LMClient)
+  }
+
+  public get audit() {
+    return this.getOrSet('audit', AuditClient)
   }
 
   public get analytics() {

--- a/node/resolvers/Mutations/CostCenters.ts
+++ b/node/resolvers/Mutations/CostCenters.ts
@@ -37,14 +37,15 @@ const CostCenters = {
       vtex,
       vtex: { logger, adminUserAuthToken },
       clients: { audit, licenseManager },
-      ip
+      ip,
     } = ctx
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
 
-
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     if (!organizationId) {
       // get user's organization from session
@@ -86,21 +87,23 @@ const CostCenters = {
         ctx
       )
 
-      // Auditoría del acceso a createCostCenter
-      await audit.sendEvent({
-        subjectId: 'create-cost-center-event',
-        operation: 'CREATE_COST_CENTER',
-        authorId: profile?.id || 'unknown',
-        meta: {
-          entityName: 'CreateCostCenter',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({
-            organizationId,
-            costCenter
-          }),
-          entityAfterAction: JSON.stringify(result),
+      await audit.sendEvent(
+        {
+          subjectId: 'create-cost-center-event',
+          operation: 'CREATE_COST_CENTER',
+          authorId: profile?.id || 'unknown',
+          meta: {
+            entityName: 'CreateCostCenter',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({
+              organizationId,
+              costCenter,
+            }),
+            entityAfterAction: JSON.stringify(result),
+          },
         },
-      }, {})
+        {}
+      )
 
       return result
     } catch (error) {
@@ -134,90 +137,94 @@ const CostCenters = {
     const {
       vtex: { logger, adminUserAuthToken },
       clients: { audit, licenseManager },
-      ip
+      ip,
     } = ctx
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
 
-
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     try {
       // check if organization exists
-    const organization = (await Organizations.getOrganizationById(
-      _,
-      { id: organizationId },
-      ctx
-    )) as {
-      status: string
-    }
+      const organization = (await Organizations.getOrganizationById(
+        _,
+        { id: organizationId },
+        ctx
+      )) as {
+        status: string
+      }
 
-    if (!organization) {
-      throw new Error('Organization not found')
-    }
+      if (!organization) {
+        throw new Error('Organization not found')
+      }
 
-    // check if cost center id already exists
-    let costCenter = null
+      // check if cost center id already exists
+      let costCenter = null
 
-    try {
-      costCenter = await costCenters.getCostCenterById(_, { id }, ctx)
-    } catch (error) {
-      costCenter = null // cost center does not exist so we don't need to do anything
-    }
+      try {
+        costCenter = await costCenters.getCostCenterById(_, { id }, ctx)
+      } catch (error) {
+        costCenter = null // cost center does not exist so we don't need to do anything
+      }
 
-    if (costCenter) {
-      throw new Error('Cost Center already exists')
-    }
+      if (costCenter) {
+        throw new Error('Cost Center already exists')
+      }
 
-    // create cost center
-    const newCostCenter: CostCenterInput = {
-      addresses,
-      businessDocument,
-      customFields,
-      marketingTags,
-      id,
-      name,
-      phoneNumber,
-      sellers,
-      stateRegistration,
-      paymentTerms,
-    }
+      // create cost center
+      const newCostCenter: CostCenterInput = {
+        addresses,
+        businessDocument,
+        customFields,
+        marketingTags,
+        id,
+        name,
+        phoneNumber,
+        sellers,
+        stateRegistration,
+        paymentTerms,
+      }
 
-    const { id: costCenterId } = await CostCenterRepository.createCostCenter(
-      _,
-      organizationId,
-      newCostCenter,
-      ctx
-    )
+      const { id: costCenterId } = await CostCenterRepository.createCostCenter(
+        _,
+        organizationId,
+        newCostCenter,
+        ctx
+      )
 
-      await audit.sendEvent({
-        subjectId: 'create-cost-center-with-id-event',
-        operation: 'CREATE_COST_CENTER_WITH_ID',
-        authorId: profile?.id || 'unknown',
-        meta: {
-          entityName: 'CreateCostCenterWithId',
-          remoteIpAddress: ip,
-        entityBeforeAction: JSON.stringify({
-          organizationId,
-          input: {
-            id,
-            name,
-            addresses,
-            phoneNumber,
-            businessDocument,
-            stateRegistration,
-            customFields,
-            marketingTags,
-            sellers,
-            paymentTerms,
-          }
-        }),
-          entityAfterAction: JSON.stringify({
-            id: costCenterId
-          }),
+      await audit.sendEvent(
+        {
+          subjectId: 'create-cost-center-with-id-event',
+          operation: 'CREATE_COST_CENTER_WITH_ID',
+          authorId: profile?.id || 'unknown',
+          meta: {
+            entityName: 'CreateCostCenterWithId',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({
+              organizationId,
+              input: {
+                id,
+                name,
+                addresses,
+                phoneNumber,
+                businessDocument,
+                stateRegistration,
+                customFields,
+                marketingTags,
+                sellers,
+                paymentTerms,
+              },
+            }),
+            entityAfterAction: JSON.stringify({
+              id: costCenterId,
+            }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { id: costCenterId }
     } catch (error) {
@@ -237,14 +244,15 @@ const CostCenters = {
     const {
       clients: { masterdata, audit, licenseManager },
       vtex: { logger, adminUserAuthToken },
-      ip
+      ip,
     } = ctx
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
 
-
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     try {
       const costCenter: CostCenterInput = await masterdata.getDocument({
@@ -265,23 +273,26 @@ const CostCenters = {
         id: costCenterId,
       })
 
-      await audit.sendEvent({
-        subjectId: 'create-cost-center-address-event',
-        operation: 'CREATE_COST_CENTER_ADDRESS',
-        authorId: profile?.id || 'unknown',
-        meta: {
-          entityName: 'CreateCostCenterAddress',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({
-            costCenterId,
-            address
-          }),
-          entityAfterAction: JSON.stringify({
-            costCenterId,
-            status: 'success'
-          }),
+      await audit.sendEvent(
+        {
+          subjectId: 'create-cost-center-address-event',
+          operation: 'CREATE_COST_CENTER_ADDRESS',
+          authorId: profile?.id || 'unknown',
+          meta: {
+            entityName: 'CreateCostCenterAddress',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({
+              costCenterId,
+              address,
+            }),
+            entityAfterAction: JSON.stringify({
+              costCenterId,
+              status: 'success',
+            }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { status: 'success', message: '' }
     } catch (error) {
@@ -297,11 +308,12 @@ const CostCenters = {
     const {
       clients: { masterdata, audit, licenseManager },
       vtex: { adminUserAuthToken },
-      ip
+      ip,
     } = ctx
 
-
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     try {
       await masterdata.deleteDocument({
@@ -309,17 +321,20 @@ const CostCenters = {
         id,
       })
 
-      await audit.sendEvent({
-        subjectId: 'delete-cost-center-event',
-        operation: 'DELETE_COST_CENTER',
-        authorId: profile.id || '',
-        meta: {
-          entityName: 'DeleteCostCenter',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({ id }),
-          entityAfterAction: JSON.stringify({ deleted: true, id }),
+      await audit.sendEvent(
+        {
+          subjectId: 'delete-cost-center-event',
+          operation: 'DELETE_COST_CENTER',
+          authorId: profile.id || '',
+          meta: {
+            entityName: 'DeleteCostCenter',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({ id }),
+            entityAfterAction: JSON.stringify({ deleted: true, id }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { status: 'success', message: '' }
     } catch (e) {
@@ -331,11 +346,12 @@ const CostCenters = {
     const {
       clients: { masterdata, audit, licenseManager },
       vtex: { adminUserAuthToken },
-      ip
+      ip,
     } = ctx
 
-  
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     try {
       await masterdata.deleteDocument({
@@ -343,17 +359,20 @@ const CostCenters = {
         id,
       })
 
-      await audit.sendEvent({
-        subjectId: 'delete-organization-event',
-        operation: 'DELETE_ORGANIZATION',
-        authorId: profile.id || '',
-        meta: {
-          entityName: 'DeleteOrganization',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({ id }),
-          entityAfterAction: JSON.stringify({ deleted: true, id }),
+      await audit.sendEvent(
+        {
+          subjectId: 'delete-organization-event',
+          operation: 'DELETE_ORGANIZATION',
+          authorId: profile.id || '',
+          meta: {
+            entityName: 'DeleteOrganization',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({ id }),
+            entityAfterAction: JSON.stringify({ deleted: true, id }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { status: 'success', message: '' }
     } catch (e) {
@@ -380,14 +399,15 @@ const CostCenters = {
     const {
       clients: { masterdata, audit, licenseManager },
       vtex: { logger, adminUserAuthToken },
-      ip
+      ip,
     } = ctx
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
 
-
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
 
     try {
       await masterdata.updatePartialDocument({
@@ -410,31 +430,34 @@ const CostCenters = {
         id,
       })
 
-      await audit.sendEvent({
-        subjectId: 'update-cost-center-event',
-        operation: 'UPDATE_COST_CENTER',
-        authorId: profile?.id || 'unknown',
-        meta: {
-          entityName: 'UpdateCostCenter',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({
-            id,
-            input: {
-              name,
-              addresses,
-              paymentTerms,
-              phoneNumber,
-              businessDocument,
-              stateRegistration,
-              customFields,
-            }
-          }),
-          entityAfterAction: JSON.stringify({
-            id,
-            status: 'success'
-          }),
+      await audit.sendEvent(
+        {
+          subjectId: 'update-cost-center-event',
+          operation: 'UPDATE_COST_CENTER',
+          authorId: profile?.id || 'unknown',
+          meta: {
+            entityName: 'UpdateCostCenter',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({
+              id,
+              input: {
+                name,
+                addresses,
+                paymentTerms,
+                phoneNumber,
+                businessDocument,
+                stateRegistration,
+                customFields,
+              },
+            }),
+            entityAfterAction: JSON.stringify({
+              id,
+              status: 'success',
+            }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { status: 'success', message: '' }
     } catch (error) {
@@ -454,13 +477,15 @@ const CostCenters = {
     const {
       clients: { masterdata, audit, licenseManager },
       vtex: { logger, adminUserAuthToken },
-      ip
+      ip,
     } = ctx
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
-    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
-    
+    const { profile } = await licenseManager.getTopbarData(
+      adminUserAuthToken ?? ''
+    )
+
     try {
       const costCenter: CostCenterInput = await masterdata.getDocument({
         dataEntity: COST_CENTER_DATA_ENTITY,
@@ -486,24 +511,27 @@ const CostCenters = {
         id: costCenterId,
       })
 
-      await audit.sendEvent({
-        subjectId: 'update-cost-center-address-event',
-        operation: 'UPDATE_COST_CENTER_ADDRESS',
-        authorId: profile?.id || 'unknown',
-        meta: {
-          entityName: 'UpdateCostCenterAddress',
-          remoteIpAddress: ip,
-          entityBeforeAction: JSON.stringify({
-            costCenterId,
-            address
-          }),
-          entityAfterAction: JSON.stringify({
-            costCenterId,
-            addresses,
-            status: 'success'
-          }),
+      await audit.sendEvent(
+        {
+          subjectId: 'update-cost-center-address-event',
+          operation: 'UPDATE_COST_CENTER_ADDRESS',
+          authorId: profile?.id || 'unknown',
+          meta: {
+            entityName: 'UpdateCostCenterAddress',
+            remoteIpAddress: ip,
+            entityBeforeAction: JSON.stringify({
+              costCenterId,
+              address,
+            }),
+            entityAfterAction: JSON.stringify({
+              costCenterId,
+              addresses,
+              status: 'success',
+            }),
+          },
         },
-      }, {})
+        {}
+      )
 
       return { status: 'success', message: '' }
     } catch (error) {

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -6,10 +6,15 @@ import type { GetSellersOpts } from '../../clients/sellers'
 const B2BSettings = {
   getB2BSettings: async (_: void, __: void, ctx: Context) => {
     const {
-      clients: { vbase },
+      clients: { vbase, audit, licenseManager },
+      vtex: { adminUserAuthToken },
+      ip
     } = ctx
 
     const B2B_SETTINGS_DATA_ENTITY = 'b2b_settings'
+
+
+    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
 
     // create schema if it doesn't exist
     await checkConfig(ctx)
@@ -36,6 +41,19 @@ const B2BSettings = {
           organizationStatusChanged: true,
         },
       }
+
+      await audit.sendEvent({
+        subjectId: 'get-b2b-settings-event',
+        operation: 'GET_B2B_SETTINGS',
+        authorId: profile.id || '',
+        meta: {
+          entityName: 'GetB2BSettings',
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify({}),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, {})
+
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)
@@ -50,10 +68,37 @@ const B2BSettings = {
   },
   getSellers: async (_: void, __: void, ctx: Context) => {
     const {
-      clients: { sellers },
+      clients: { sellers, audit, licenseManager },
+      vtex: { logger, adminUserAuthToken },
+      ip
     } = ctx
 
-    return (await sellers.getSellers())?.items
+
+    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+
+    try {
+      const result = await sellers.getSellers()
+
+      await audit.sendEvent({
+        subjectId: 'get-sellers-event',
+        operation: 'GET_SELLERS',
+        authorId: profile.id || '',
+        meta: {
+          entityName: 'GetSellers',
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify({}),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, { })
+
+      return result?.items
+    } catch (error) {
+      logger.error({
+        error,
+        message: 'getSellers-error',
+      })
+      return []
+    }
   },
   getSellersPaginated: async (
     _: void,
@@ -61,11 +106,30 @@ const B2BSettings = {
     ctx: Context
   ) => {
     const {
-      clients: { sellers },
+      clients: { sellers, audit, licenseManager },
+      vtex: { adminUserAuthToken },
+      ip
     } = ctx
 
+
+    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+
     try {
-      return await sellers.getSellersPaginated(options)
+      const result = await sellers.getSellersPaginated(options)
+
+      await audit.sendEvent({
+        subjectId: 'get-sellers-paginated-event',
+        operation: 'GET_SELLERS_PAGINATED',
+        authorId: profile.id || '',
+        meta: {
+          entityName: 'GetSellersPaginated',
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify(options),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, {})
+
+      return result
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)
@@ -78,10 +142,32 @@ const B2BSettings = {
   },
   getAccount: async (_: void, __: void, ctx: Context) => {
     const {
-      clients: { lm },
+      clients: { lm, audit, licenseManager },
+      vtex: { adminUserAuthToken },
+      ip
     } = ctx
 
-    return lm.getAccount().catch((e) => {
+
+    const { profile } = await licenseManager.getTopbarData(adminUserAuthToken ?? '')
+
+    try {
+      const result = await lm.getAccount()
+
+      await audit.sendEvent({
+        subjectId: 'get-account-event',
+        operation: 'GET_ACCOUNT',
+        authorId: profile.id || '',
+        meta: {
+          entityName: 'GetAccount',
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify({}),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, {})
+
+      return result
+    } catch (e) {
+
       if (e.message) {
         throw new GraphQLError(e.message)
       } else if (e.response?.data?.message) {
@@ -89,7 +175,7 @@ const B2BSettings = {
       } else {
         throw new GraphQLError(e)
       }
-    })
+    }
   },
 }
 

--- a/node/resolvers/directives/validateAdminUserAccess.ts
+++ b/node/resolvers/directives/validateAdminUserAccess.ts
@@ -123,6 +123,17 @@ export class ValidateAdminUserAccess extends SchemaDirectiveVisitor {
 
       // deny access if no tokens were provided
       if (!hasAdminToken && !hasAdminTokenOnHeader && !hasApiToken) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateAdminUserAccessAudit'
+          ),
+          401,
+          false
+        )
         logger.warn({
           message: 'ValidateAdminUserAccess: No token provided',
           ...metricFields,
@@ -131,6 +142,18 @@ export class ValidateAdminUserAccess extends SchemaDirectiveVisitor {
       }
 
       // deny access if no valid tokens were provided
+
+      sendAuthMetric(
+        context,
+        logger,
+        new AuthMetric(
+          context?.vtex?.account,
+          metricFields,
+          'ValidateAdminUserAccessAudit'
+        ),
+        403,
+        false
+      )
       logger.warn({
         message: 'ValidateAdminUserAccess: Invalid token',
         ...metricFields,

--- a/node/resolvers/directives/validateStoreUserAccess.ts
+++ b/node/resolvers/directives/validateStoreUserAccess.ts
@@ -120,9 +120,8 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
             context?.vtex?.account,
             metricFields,
             'ValidateStoreUserAccessAudit'
-          )
+          ),
         )
-
         return resolve(root, args, context, info)
       }
 
@@ -155,6 +154,17 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
 
       // deny access if no tokens were provided
       if (!hasAdminToken && !hasApiToken && !hasStoreToken) {
+        sendAuthMetric(
+          context,
+          logger,
+          new AuthMetric(
+            context?.vtex?.account,
+            metricFields,
+            'ValidateStoreUserAccessAudit'
+          ),
+          401,
+          false
+        )
         logger.warn({
           message: 'ValidateStoreUserAccess: No token provided',
           ...metricFields,
@@ -163,6 +173,17 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
       }
 
       // deny access if no valid tokens were provided
+      sendAuthMetric(
+        context,
+        logger,
+        new AuthMetric(
+          context?.vtex?.account,
+          metricFields,
+          'ValidateStoreUserAccessAudit'
+        ),
+        403,
+        false
+      )
       logger.warn({
         message: `ValidateStoreUserAccess: Invalid token`,
         ...metricFields,

--- a/node/typings/domain/index.ts
+++ b/node/typings/domain/index.ts
@@ -1,0 +1,11 @@
+ type AuditEntry = {
+  subjectId: string
+  operation: string
+  authorId: string
+  meta: {
+    entityName: string
+    remoteIpAddress: string
+    entityBeforeAction: string
+    entityAfterAction: string
+  }
+}

--- a/node/utils/metrics/auth.ts
+++ b/node/utils/metrics/auth.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@vtex/api/lib/service/logger/logger'
 
 import type { Metric } from '../../clients/analytics'
 import { B2B_METRIC_NAME } from '../../clients/analytics'
+import { transformOperation } from './transformOperation'
 
 export interface AuthAuditMetric {
   operation: string
@@ -39,14 +40,48 @@ export class AuthMetric implements Metric {
 const sendAuthMetric = async (
   ctx: Context,
   logger: Logger,
-  authMetric: AuthMetric
+  authMetric: AuthMetric,
+  statusCode?: number,
+  shouldSendMetrics: boolean = true
 ) => {
   const {
-    clients: { analytics },
+    clients: { analytics, audit },
+    ip,
   } = ctx
 
+  const { subjectId, operation, entityNameFirstLetter } = transformOperation(authMetric.fields.operation, statusCode);
+
+
   try {
-    await analytics.sendMetric(authMetric)
+    if (statusCode === 403) {
+      await audit.sendEvent({
+        subjectId: subjectId,
+        operation: operation,
+        authorId: "unknown",
+        meta: {
+          entityName: entityNameFirstLetter,
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify({}),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, { logger })
+    } else if (statusCode === 401) {
+      await audit.sendEvent({
+        subjectId: subjectId,
+        operation: operation,
+        authorId: "unknown",
+        meta: {
+          entityName: entityNameFirstLetter,
+          remoteIpAddress: ip,
+          entityBeforeAction: JSON.stringify({}),
+          entityAfterAction: JSON.stringify({}),
+        },
+      }, {})
+    }
+    
+    if (shouldSendMetrics) {
+      await analytics.sendMetric(authMetric)
+    }
   } catch (error) {
     logger.error({
       error,

--- a/node/utils/metrics/transformOperation.ts
+++ b/node/utils/metrics/transformOperation.ts
@@ -1,0 +1,27 @@
+export function transformOperation(operation: string, statusCode?: number) {
+    const snakeCase = operation
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .toUpperCase();
+  
+    const baseName = operation
+      .replace(/([A-Z])/g, '-$1')
+      .toLowerCase()
+      .replace(/^-/, '');
+  
+    const entityNameFirstLetter = operation.charAt(0).toUpperCase() + operation.slice(1);
+  
+    let subjectId = `${baseName}-unauthorized-error-event`;
+    let operationName = `${snakeCase}-UNAUTHORIZED_ERROR`;
+  
+    if (statusCode === 403) {
+      subjectId = `${baseName}-forbidden-error-event`;
+      operationName = `${snakeCase}-FORBIDDEN_ERROR`;
+    }
+  
+    return {
+      subjectId,
+      operation: operationName,
+      entityNameFirstLetter,
+    };
+  }
+  


### PR DESCRIPTION
#### What problem is this solving?
Audit logs were added to queries and mutations in the B2B Organizations GraphQL repository in order to improve traceability and change control.
These audits leverage the existing permission validation directives, so the audit flow is aligned with the same authorization checks already in place.

<!--- What is the motivation and context for this change? -->
The motivation for this change is to add auditing to queries and mutations in the B2B Organizations GraphQL repository to improve traceability and accountability.

#### How to test it?
1) Link this branch to a Workspace.

2) Run the audited queries and mutations using the GraphQL IDE or verify them through the Admin Audit section.

3) Confirm that audit logs are generated correctly.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://jaraudit--vpcldev.myvtex.com/)

#### Screenshots or example usage:
These examples were taken from the GraphQL IDE.

successful
<img width="1001" height="572" alt="image" src="https://github.com/user-attachments/assets/9d344530-fc75-4699-a32e-324d10a5977e" />

unauthorized
<img width="803" height="576" alt="image" src="https://github.com/user-attachments/assets/99b49fb5-c2f3-4a35-a490-8c1956a35cd7" />

forbidden
<img width="801" height="577" alt="image" src="https://github.com/user-attachments/assets/7a5fc449-9210-463a-842f-9608e9858dd5" />]