### PR TITLE
chore: major update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@2.x
+    - vtex.b2b-checkout-settings@3.x
+    - vtex.b2b-my-account@2.x
+    - vtex.b2b-orders-history@2.x
+    - vtex.b2b-organizations@3.x
+    - vtex.b2b-organizations-graphql@2.x
+    - vtex.b2b-quotes@3.x
+    - vtex.b2b-quotes-graphql@4.x
+    - vtex.b2b-suite@2.x
+    - vtex.b2b-theme@5.x
+    - vtex.storefront-permissions-components@2.x
+    - vtex.storefront-permissions-ui@1.x
+
 ### Feature
 - Added license manager permissions for read/write access (Product 97 Buyer Organizations View and Edit)
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "graphql": "1.x"
   },
   "dependencies": {
-    "vtex.storefront-permissions": "2.x"
+    "vtex.storefront-permissions": "3.x"
   },
   "policies": [
     {

--- a/node/clients/storefrontPermissions.ts
+++ b/node/clients/storefrontPermissions.ts
@@ -19,7 +19,7 @@ import listUsersPaginated from '../queries/listUsersPaginated'
 
 export default class StorefrontPermissions extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.storefront-permissions@2.x', ctx, options)
+    super('vtex.storefront-permissions@3.x', ctx, options)
   }
 
   public checkUserPermission = async (app?: string): Promise<any> => {
@@ -337,11 +337,11 @@ export default class StorefrontPermissions extends AppGraphQLClient {
   }
 
   private getPersistedQuery = (
-    sender = 'vtex.b2b-organizations-graphql@1.x'
+    sender = 'vtex.b2b-organizations-graphql@2.x'
   ) => {
     return {
       persistedQuery: {
-        provider: 'vtex.storefront-permissions@2.x',
+        provider: 'vtex.storefront-permissions@3.x',
         sender,
       },
     }

--- a/node/resolvers/Queries/CostCenters.ts
+++ b/node/resolvers/Queries/CostCenters.ts
@@ -317,7 +317,7 @@ const costCenters = {
 
     if (sessionData?.namespaces) {
       const checkUserPermissionResult = await storefrontPermissions
-        .checkUserPermission('vtex.b2b-organizations@2.x')
+        .checkUserPermission('vtex.b2b-organizations@3.x')
         .catch((error: any) => {
           logger.error({
             error,

--- a/node/resolvers/Queries/Organizations.ts
+++ b/node/resolvers/Queries/Organizations.ts
@@ -214,7 +214,7 @@ const Organizations = {
 
     if (sessionData?.namespaces) {
       const checkUserPermissionResult = await storefrontPermissions
-        .checkUserPermission('vtex.b2b-organizations@2.x')
+        .checkUserPermission('vtex.b2b-organizations@3.x')
         .catch((error: any) => {
           logger.error({
             error,

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -63,7 +63,7 @@ const getCheckUserPermission = async ({
   const {
     data: { checkUserPermission },
   }: any = await storefrontPermissions
-    .checkUserPermission('vtex.b2b-organizations@2.x')
+    .checkUserPermission('vtex.b2b-organizations@3.x')
     .catch((error: any) => {
       logger.error({
         error,

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -40,7 +40,7 @@ const getUserAndPermissions = async (ctx: Context) => {
   if (sessionData?.namespaces) {
     const checkUserPermissionResult = await storefrontPermissions
       // It is necessary to send the app name, because the check user return the permissions relative to orders-history to access the page.
-      .checkUserPermission('vtex.b2b-orders-history@1.x')
+      .checkUserPermission('vtex.b2b-orders-history@2.x')
       .catch((error: any) => {
         logger.error({
           message: 'checkUserPermission-error',

--- a/node/resolvers/directives/withPermissions.ts
+++ b/node/resolvers/directives/withPermissions.ts
@@ -8,7 +8,7 @@ import type StorefrontPermissions from '../../clients/storefrontPermissions'
 
 export const getUserPermission = async (
   storefrontPermissions: StorefrontPermissions,
-  app = 'vtex.b2b-organizations@2.x'
+  app = 'vtex.b2b-organizations@3.x'
 ) => {
   const result = await storefrontPermissions.checkUserPermission(app)
 


### PR DESCRIPTION
**What problem is this solving?**

Generating new major version. This new version includes ACL feature. Now the following permissions are needed to view/edit organizations within the admin UI app:
`Buyer Organizations / buyer_organization_view`
`Buyer Organizations / buyer_organization_edit`

If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
    - vtex.b2b-admin-customers@2.x
    - vtex.b2b-checkout-settings@3.x
    - vtex.b2b-my-account@2.x
    - vtex.b2b-orders-history@2.x
    - vtex.b2b-organizations@3.x
    - vtex.b2b-organizations-graphql@2.x
    - vtex.b2b-quotes@3.x
    - vtex.b2b-quotes-graphql@4.x
    - vtex.b2b-suite@2.x
    - vtex.b2b-theme@5.x
    - vtex.storefront-permissions-components@2.x
    - vtex.storefront-permissions-ui@1.x