### PR TITLE
Fix fullImpersonation in B2B settings mutation

### DIFF
--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -128,6 +128,7 @@ const Settings = {
           clearCart:
             uiSettings?.clearCart ?? currentB2BSettings?.uiSettings?.clearCart,
           topBar: uiSettings?.topBar ?? currentB2BSettings?.uiSettings?.topBar,
+          fullImpersonation: uiSettings?.fullImpersonation ?? currentB2BSettings?.uiSettings?.fullImpersonation,
         },
       }
 


### PR DESCRIPTION
fix: add b2bSettings.uiSettings.fullImpersonation to b2bSettings mutation

#### What problem is this solving?

The `uiSettings.fullImpersonation` property is currently not being set or maintained by the `saveB2BSettings` mutation.

<img width="642" height="112" alt="image" src="https://github.com/user-attachments/assets/1c091fb9-0fae-4dcd-9af7-3ba11a4f9b1e" />

<img width="670" height="112" alt="image" src="https://github.com/user-attachments/assets/106ca05b-90ce-44e2-a0b4-e056361aa298" />

This issue prevents setting the property both on the Organizations UI and via graphQL mutation.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

This query can be used to verify current settings directly on graphQL admin page:

```
query{
  getB2BSettings{
    uiSettings{
      fullImpersonation
    }
  }
}
```

This mutation can be used to change the `uiSettings.fullImpersonation` setting: 

```
mutation {
  saveB2BSettings(input: {uiSettings: {fullImpersonation: true}}) {
    id
    status
    message
  }
}
```

The fix can be tested on [this workspace](https://testetiago--b2bstore005.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage:

Example in workspace with the applied fix:

<img width="893" height="298" alt="image" src="https://github.com/user-attachments/assets/41acbd09-35d4-4c10-a9ed-41c461205310" />
<img width="893" height="298" alt="image" src="https://github.com/user-attachments/assets/9570feb3-7ddc-4e7b-aa16-a086ed35610f" />


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
