### PR TITLE
[B2BTEAM-3516] Fixed collections being set as null after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`updateOrganization` collections**: resolve `CollectionInput` entries by Catalog name when no `id` is sent, matching `createOrganizationAndCostCentersWithId`/`NormalizedOrganizationInput` behavior so storefront catalog rules stay valid after updates.
+- **Partial updates**: only send `collections` to Master Data when the argument is explicitly provided (`undefined`/omitted leaves existing collections unchanged).
+- **`findCollections`**: drop unresolved entries after Catalog lookup instead of leaving nulls in the stored array.
+
 ## [2.4.4] - 2026-03-14
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -192,6 +192,13 @@ type Mutation {
   ): MasterDataResponse
     @validateAdminUserAccess(adminPermission: "B2B_ORGANIZATIONS_EDIT")
     @cacheControl(scope: PRIVATE)
+  """
+  When `collections` is omitted from the mutation call, existing organization collections are left unchanged.
+
+  Entries with both `id` and `name` are persisted without Catalog lookup (`id` is authoritative).
+
+  When `id` is omitted and `name` is provided, matching follows the same Catalog name resolution used by `createOrganizationAndCostCentersWithId`/`NormalizedOrganizationInput`.
+  """
   updateOrganization(
     id: ID!
     name: String!
@@ -661,6 +668,11 @@ input AddressInput {
   reference: String
 }
 
+"""
+Collection attachment for an organization. For updates, omit `id` only when resolving the collection via Catalog exact `name` match (parity with normalized create input using collection names).
+
+When both are provided, `id` wins and no Catalog lookup is performed for that row.
+"""
 input CollectionInput {
   id: String
   name: String

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "vtex",
-  "version": "2.4.4",
+  "version": "2.4.5-beta.0",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/node/resolvers/Mutations/Organizations.test.ts
+++ b/node/resolvers/Mutations/Organizations.test.ts
@@ -19,11 +19,12 @@ import {
 } from '../../mdSchema'
 import type {
   AddressInput,
+  Collection,
   NormalizedOrganizationInput,
   OrganizationInput,
   OrganizationRequest,
 } from '../../typings'
-import { ORGANIZATION_REQUEST_STATUSES } from '../../utils/constants'
+import { ORGANIZATION_REQUEST_STATUSES, ORGANIZATION_STATUSES } from '../../utils/constants'
 import Organizations from './Organizations'
 
 jest.mock('@vtex/api')
@@ -49,9 +50,16 @@ const mockContext = (
   costId: string = randUuid()
 ) => {
   return {
+    ip: '127.0.0.1',
     clients: {
       analytics: {
-        sendMetric: jest.fn(),
+        sendMetric: jest.fn().mockResolvedValue(undefined),
+      },
+      audit: {
+        sendEvent: jest.fn().mockResolvedValue(undefined),
+      },
+      catalog: {
+        collectionsAvailable: jest.fn().mockResolvedValue({ items: [] }),
       },
       masterdata: {
         createDocument: jest
@@ -76,7 +84,12 @@ const mockContext = (
       },
     },
     vtex: {
-      logger: jest.fn(),
+      account: 'mock-account',
+      logger: {
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+      },
     },
   } as unknown as Context
 }
@@ -427,6 +440,157 @@ describe('given an Organization Mutation', () => {
       })
       it('should create the organization with the id specified', () => {
         expect(result.id).toEqual(orgId)
+      })
+    })
+  })
+
+  describe('when updateOrganization is invoked', () => {
+    const orgId = randUuid()
+
+    let collectionsAvailableSpy: jest.Mock
+    let mockedContext: Context
+
+    const minimalUpdateArgs = {
+      customFields: [],
+      id: orgId,
+      name: 'Updated Org',
+      notifyUsers: false,
+      paymentTerms: [],
+      permissions: {},
+      priceTables: [],
+      sellers: undefined,
+      status: ORGANIZATION_STATUSES.ACTIVE,
+      tradeName: undefined as string | undefined,
+    }
+
+    beforeEach(() => {
+      collectionsAvailableSpy = jest.fn()
+
+      mockedContext = {
+        ip: '127.0.0.1',
+        clients: {
+          analytics: {
+            sendMetric: jest.fn().mockResolvedValue(undefined),
+          },
+          audit: {
+            sendEvent: jest.fn().mockResolvedValue(undefined),
+          },
+          catalog: {
+            collectionsAvailable: collectionsAvailableSpy,
+          },
+          mail: {},
+          masterdata: {
+            getDocument: jest.fn().mockResolvedValue({
+              id: orgId,
+              name: 'Existing',
+              status: ORGANIZATION_STATUSES.ACTIVE,
+            }),
+            updatePartialDocument: jest.fn().mockResolvedValue({}),
+          },
+          storefrontPermissions: {},
+        },
+        vtex: {
+          account: 'testacct',
+          logger: {
+            error: jest.fn(),
+            warn: jest.fn(),
+          },
+        },
+      } as unknown as Context
+    })
+
+    describe('collections resolution', () => {
+      const getPersistedCollections = (): Collection[] =>
+        (mockedContext.clients.masterdata.updatePartialDocument as jest.Mock)
+          .mock.calls[0]?.[0].fields.collections ?? []
+
+      it('resolves Catalog id from name-only payloads', async () => {
+        collectionsAvailableSpy.mockResolvedValue({
+          items: [{ id: 42, name: 'VIP Shelf' }],
+        })
+
+        await Organizations.updateOrganization(jest.fn() as never, {
+          ...minimalUpdateArgs,
+          collections: [{ name: 'VIP Shelf' }],
+        } as never, mockedContext)
+
+        expect(getPersistedCollections()).toEqual([
+          { id: '42', name: 'VIP Shelf' },
+        ])
+        expect(collectionsAvailableSpy).toHaveBeenCalledWith('VIP Shelf')
+      })
+
+      it('does not resolve via Catalog when id is supplied', async () => {
+        await Organizations.updateOrganization(jest.fn() as never, {
+          ...minimalUpdateArgs,
+          collections: [{ id: '77', name: 'Direct Attach' }],
+        } as never, mockedContext)
+
+        expect(collectionsAvailableSpy).not.toHaveBeenCalled()
+
+        expect(getPersistedCollections()).toEqual([
+          { id: '77', name: 'Direct Attach' },
+        ])
+      })
+
+      it('preserves order for mixed explicit-id and resolved-by-name inputs', async () => {
+        collectionsAvailableSpy.mockResolvedValueOnce({
+          items: [{ id: 200, name: 'LateBound' }],
+        })
+
+        await Organizations.updateOrganization(jest.fn() as never, {
+          ...minimalUpdateArgs,
+          collections: [
+            { id: '5', name: 'FirstDirect' },
+            { name: 'LateBound' },
+          ],
+        } as never, mockedContext)
+
+        expect(getPersistedCollections()).toEqual([
+          { id: '5', name: 'FirstDirect' },
+          { id: '200', name: 'LateBound' },
+        ])
+
+        expect(collectionsAvailableSpy).toHaveBeenCalledTimes(1)
+        expect(collectionsAvailableSpy).toHaveBeenCalledWith('LateBound')
+      })
+
+      it('drops unresolved collection names aligned with normalized create semantics', async () => {
+        collectionsAvailableSpy.mockResolvedValue({ items: [] })
+
+        await Organizations.updateOrganization(jest.fn() as never, {
+          ...minimalUpdateArgs,
+          collections: [{ name: 'Unknown Collection' }],
+        } as never, mockedContext)
+
+        expect(getPersistedCollections()).toEqual([])
+      })
+
+      it('persists explicit empty arrays to clear collections', async () => {
+        await Organizations.updateOrganization(jest.fn() as never, {
+          ...minimalUpdateArgs,
+          collections: [],
+        } as never, mockedContext)
+
+        expect(mockedContext.clients.masterdata.updatePartialDocument).toHaveBeenCalled()
+
+        expect(collectionsAvailableSpy).not.toHaveBeenCalled()
+
+        expect(getPersistedCollections()).toEqual([])
+      })
+
+      it('omits collections from partial update payloads when collections argument absent', async () => {
+        await Organizations.updateOrganization(
+          jest.fn() as never,
+          minimalUpdateArgs as never,
+          mockedContext
+        )
+
+        const fields =
+          (mockedContext.clients.masterdata.updatePartialDocument as jest.Mock)
+            .mock.calls[0]?.[0].fields
+
+        expect(fields).not.toHaveProperty('collections')
       })
     })
   })

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -167,33 +167,80 @@ const findSellers = async (sellerNames: string[], ctx: Context) => {
   return sellersFound
 }
 
-const findCollections = async (collectionsNames: string[], ctx: Context) => {
+const trimmedNonEmptyString = (value?: string | null) => {
+  if (value === undefined || value === null) return ''
+  const s = String(value).trim()
+
+  return s.length > 0 ? s : ''
+}
+
+const lookupCollectionByExactName = async (
+  collectionName: string,
+  ctx: Context
+): Promise<Collection | null> => {
   const {
     clients: { catalog },
   } = ctx
 
-  const collectionsFound = collectionsNames
-    .map(async (collectionName: string) => {
-      const availableCollections = (
-        await catalog.collectionsAvailable(collectionName)
-      )?.items
+  const availableCollections = (
+    await catalog.collectionsAvailable(collectionName)
+  )?.items
 
-      const collection = availableCollections.find(
-        (c: any) => c.name === collectionName
-      )
+  const collection = availableCollections?.find(
+    (c: any) => c.name === collectionName
+  )
 
-      if (collection) {
+  if (collection) {
+    return {
+      id: collection.id.toString(),
+      name: collection.name,
+    } as Collection
+  }
+
+  return null
+}
+
+const findCollections = async (collectionsNames: string[], ctx: Context) => {
+  const resolved = await Promise.all(
+    collectionsNames.map((name) =>
+      lookupCollectionByExactName(name.trim(), ctx)
+    )
+  )
+
+  return resolved.filter((item): item is Collection => item !== null)
+}
+
+/**
+ * When `collections` arg is omitted in `updateOrganization`, Master Data collections are untouched.
+ */
+const resolveCollectionInputsForMutation = async (
+  collectionInputs: Array<{ id?: string | null; name?: string | null }>,
+  ctx: Context
+): Promise<Collection[]> => {
+  const resolved = await Promise.all(
+    collectionInputs.map(async (item) => {
+      const trimmedId = trimmedNonEmptyString(item?.id)
+
+      if (trimmedId) {
+        const trimmedName = trimmedNonEmptyString(item?.name)
+
         return {
-          id: collection.id.toString(),
-          name: collection.name,
+          id: trimmedId,
+          ...(trimmedName && { name: trimmedName }),
         } as Collection
+      }
+
+      const trimmedNameOnly = trimmedNonEmptyString(item?.name)
+
+      if (trimmedNameOnly) {
+        return lookupCollectionByExactName(trimmedNameOnly, ctx)
       }
 
       return null
     })
-    .filter((collection: any) => collection !== null)
+  )
 
-  return Promise.all(collectionsFound)
+  return resolved.filter((item): item is Collection => item !== null)
 }
 
 const createOrganizationAndCostCenterWithAdminUser = async (
@@ -713,7 +760,7 @@ const Organizations = {
       name: string
       tradeName?: string
       status: string
-      collections: any[]
+      collections?: any[] | null
       paymentTerms: any[]
       priceTables: any[]
       customFields: any[]
@@ -767,8 +814,18 @@ const Organizations = {
     }
 
     try {
+      const shouldPersistCollections =
+        collections !== undefined && collections !== null
+
+      const persistedCollections =
+        shouldPersistCollections && collections
+          ? await resolveCollectionInputsForMutation(collections, ctx)
+          : undefined
+
       const fields = {
-        collections,
+        ...(shouldPersistCollections && {
+          collections: persistedCollections,
+        }),
         ...((tradeName || tradeName === '') && { tradeName }),
         customFields,
         name,


### PR DESCRIPTION


#### What problem is this solving?

Partners integrating with B2B Organizations hit an inconsistency between **`createOrganizationAndCostCentersWithId`** (which accepts collection **names** via `NormalizedOrganizationInput` and resolves Catalog `{ id, name }`) and **`updateOrganization`** (which persisted `CollectionInput` as-is). Payloads with only `{ name }` stored collections **without a valid `id`**, breaking storefront catalog behavior after an update.

This change **resolves name-only `CollectionInput` rows** on update using the same Catalog lookup as create, **keeps full backward compatibility** when `id` is provided, and **only writes `collections` to Master Data when the argument is explicitly sent** so omitted `collections` no longer risk clearing existing data. **`findCollections`** also filters out unresolved entries after lookup instead of leaving nulls in the array.

GraphQL schema docs were updated for `updateOrganization` and `CollectionInput`; **CHANGELOG** updated under Unreleased.

---

#### How to test it?

- [ ] Link a **development workspace** where this app version is linked (e.g. `vtex link` on this branch).
- [ ] **Create** an org with `createOrganizationAndCostCentersWithId` using `collections: ["<existing collection name>"]`.
- [ ] **Query** `getOrganizationById` and confirm `collections` have both `id` and `name`.
- [ ] **Update** the same org with `updateOrganization`, passing `collections: [{ name: "<same name>" }]` only (no `id`); query again and confirm **`id` is still present** and matches Catalog.
- [ ] **Update** with `collections: [{ id: "...", name: "..." }]` and confirm behavior unchanged for existing integrations.
- [ ] **Update** without the `collections` argument and confirm **existing collections are unchanged** in Master Data.
- [ ] (Optional) Run unit tests: `cd node && yarn test Organizations.test.ts`.

**Workspace link:** _&lt;add your workspace URL here, e.g. `https://workspace--account.myvtex.com/admin/graphql-ide` 



#### Screenshots or example usage:
Result before the fix:
<img width="2246" height="1162" alt="image" src="https://github.com/user-attachments/assets/012130c6-5330-426d-988a-0da3104e6b4a" />

Result after the fix
<img width="2186" height="1208" alt="image" src="https://github.com/user-attachments/assets/174c1f05-0d93-4b9c-b78f-04601e524642" />


