### PR TITLE
Feature/b2b team 3521 export bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- GraphQL bulk export API: `createExport` mutation and `exportStatus` query for `organizations`, `cost_centers`, `members`, and `addresses`
+- Integration with `b2b-bulk-import` service and private CSV download route at `GET /_v/private/b2b/export/:exportId`
+- XLSX to UTF-8 BOM CSV conversion with column normalization for organizations and cost centers; passthrough for members and addresses
+- Export metadata and CSV caching in VBase (CSV expires after 5 minutes)
+- Export usage documentation in `docs/README.md`
+
+### Changed
+
+- Throttled VBase writes during export status polling to reduce rate-limit errors
+
 ## [2.4.4] - 2026-03-14
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,223 @@
 # B2B Organizations GraphQL
 
 GraphQL backend for [B2B Organizations](https://github.com/vtex-apps/b2b-organizations).
+
+## Bulk export
+
+This app exposes a GraphQL layer on top of the `b2b-bulk-import` export service. It starts async exports, polls job status, converts completed XLSX files to UTF-8 CSV (with BOM), and serves downloads through a private HTTP route.
+
+The frontend should orchestrate the flow only; it does not transform export data.
+
+### Architecture
+
+```
+Admin UI
+  → createExport (GraphQL)
+  → b2b-bulk-import (XLSX generation)
+  → exportStatus polling (GraphQL)
+  → GET /_v/private/b2b/export/:exportId (CSV download)
+```
+
+Conversion from XLSX to CSV happens **lazily on the first download request**, not during status polling. This avoids GraphQL timeouts on large exports.
+
+---
+
+## GraphQL API
+
+Both operations require admin authentication via `@validateAdminUserAccess` with the default permission **`B2B_ORGANIZATIONS_VIEW`** (`buyer_organization_view` in License Manager). They do **not** require `B2B_ORGANIZATIONS_EDIT`.
+
+Use the VTEX Admin GraphQL endpoint (private):
+
+```
+POST /_v/private/graphql/v1?workspace={workspace}&domain=admin&locale=en-US
+```
+
+Authenticated requests must include a valid `VtexIdclientAutCookie` for an admin user on the target account.
+
+### Mutation: `createExport`
+
+Starts an export job for the entire account (no filters or partial exports).
+
+```graphql
+mutation CreateExport($exportType: ExportType!) {
+  createExport(exportType: $exportType) {
+    exportId
+  }
+}
+```
+
+**`ExportType` values:**
+
+| Value | Description |
+| --- | --- |
+| `organizations` | All buyer organizations |
+| `cost_centers` | All cost centers |
+| `members` | All B2B users / members |
+| `addresses` | All cost center addresses |
+
+On success, the app stores export metadata in VBase (`exportType`, `totalRows` when available) keyed by `exportId`. The actual CSV file is **not** created until download.
+
+### Query: `exportStatus`
+
+Poll export progress until `status` is `COMPLETED` or `FAILED`.
+
+```graphql
+query ExportStatus($exportId: String!) {
+  exportStatus(exportId: $exportId) {
+    exportId
+    status
+    progressPercentage
+    exportedRows
+    linkToFile
+    lastUpdate
+    startDate
+  }
+}
+```
+
+**`ExportStatus` values:**
+
+| Status | Meaning |
+| --- | --- |
+| `IN_PROGRESS` | Export still running in `b2b-bulk-import` |
+| `COMPLETED` | XLSX ready; `linkToFile` points to this app's download route |
+| `FAILED` | Export failed |
+
+**Progress notes:**
+
+- `progressPercentage` may be `null` when progress cannot be calculated reliably (prefer showing an indeterminate state over `0%` when rows are already being exported).
+- When `b2b-bulk-import` returns `progressPercentage: 0` but `exportedRows > 0`, the backend may compute progress from `exportedRows / totalRows` when `totalRows` was stored at `createExport`.
+- Keep polling while `status === IN_PROGRESS` even if `progressPercentage === 100`; the bulk service can report 100% before the job is fully finalized.
+- `linkToFile` is only set when `status === COMPLETED`.
+
+**Example completed response:**
+
+```json
+{
+  "exportId": "88649d8d-f065-4400-8901-79ee64c87604",
+  "status": "COMPLETED",
+  "progressPercentage": 100,
+  "exportedRows": 6997,
+  "linkToFile": "https://{workspace}--{account}.myvtex.com/_v/private/b2b/export/88649d8d-f065-4400-8901-79ee64c87604"
+}
+```
+
+---
+
+## HTTP route: CSV download
+
+| Method | Path | Auth |
+| --- | --- | --- |
+| `GET` | `/_v/private/b2b/export/:exportId` | Admin token + `buyer_organization_view` |
+
+The route is registered as `public: true` in `service.json` (reachable at the URL), but the handler rejects unauthenticated or unauthorized requests with `403 Access denied`.
+
+**First download for an export:**
+
+1. Fetches status from `b2b-bulk-import`
+2. Downloads the XLSX from the presigned URL returned by bulk-import
+3. Converts to CSV (UTF-8 with BOM)
+4. Saves a copy in VBase
+5. Streams the CSV to the client
+
+**Subsequent downloads** within the retention window serve the cached CSV from VBase without re-converting.
+
+**Browser usage:** open `linkToFile` from `exportStatus` while logged into VTEX Admin (the session cookie is sent automatically). For scripts, pass `VtexIdclientAutCookie` explicitly.
+
+Unlike the GraphQL operations, this route does **not** accept App Key / API token authentication—only admin user tokens.
+
+---
+
+## CSV output
+
+### File format
+
+- Encoding: **UTF-8 with BOM** (Excel-friendly on Windows)
+- Filename pattern: `b2b-export-{exportType}-{YYYY-MM-DD}.csv`
+- Array fields: joined with `|`
+- Custom fields: serialized as JSON where applicable
+
+### Columns by export type
+
+**`organizations`** — normalized column set:
+
+| Column | Notes |
+| --- | --- |
+| Id | |
+| Name | |
+| Trade Name | |
+| Collections | pipe-separated |
+| Price Tables | pipe-separated |
+| Payment Terms | pipe-separated |
+| Sales Channel | |
+| Sellers | pipe-separated |
+| Status | |
+| Created | |
+| Custom Fields | JSON |
+
+**`cost_centers`** — normalized column set:
+
+| Column | Notes |
+| --- | --- |
+| Organization Id | |
+| Cost Center Id | |
+| Name | |
+| Payment Terms | pipe-separated |
+| Phone Number | |
+| Business Document | |
+| State Registration | |
+| Sellers | pipe-separated |
+| Custom Fields | JSON |
+
+**`members`** and **`addresses`** — **passthrough**: CSV headers match the XLSX produced by `b2b-bulk-import` without column remapping in this app. Refer to the bulk-import service or download a sample export to see exact headers for your account.
+
+---
+
+## VBase storage
+
+Bucket: `b2b_exports`
+
+| Key | Content | When written |
+| --- | --- | --- |
+| `{exportId}` | JSON metadata (`exportType`, `totalRows`, `lastStatusSnapshot`, etc.) | `createExport`; snapshot updated during polling (throttled) |
+| `{exportId}.csv` | Converted CSV file | First successful download |
+
+**CSV retention:** the cached CSV expires **5 minutes** after it is saved (`EXPORT_CSV_VBASE_TTL_SECONDS = 300`). After expiration, a new download triggers conversion again if the source XLSX is still available from bulk-import.
+
+JSON metadata is not automatically purged by this TTL.
+
+There is no automatic cleanup job for old export metadata.
+
+---
+
+## Authentication summary
+
+| Endpoint | Permission | Token sources |
+| --- | --- | --- |
+| `createExport` | `buyer_organization_view` | Admin cookie (context or header), App Key |
+| `exportStatus` | `buyer_organization_view` | Admin cookie (context or header), App Key |
+| `GET /_v/private/b2b/export/:exportId` | `buyer_organization_view` | Admin user token only |
+
+Validation uses VTEX Identity (`audience: admin`, matching account) and License Manager role checks.
+
+---
+
+## Recommended client flow
+
+1. Call `createExport(exportType)` and store `exportId`.
+2. Poll `exportStatus(exportId)` every few seconds until `status` is terminal.
+3. When `status === COMPLETED`, download via `linkToFile` (or build the URL with `exportId`).
+4. Treat `progressPercentage: null` as “in progress” rather than 0%.
+5. On `FAILED`, surface an error and allow the user to start a new export.
+
+---
+
+## External dependency
+
+Export job execution and XLSX generation are handled by:
+
+```
+https://b2b-bulk-import.vtexcommercestable.com.br/api/b2b/export
+```
+
+This app proxies create/status requests and converts the completed file for download. Export failures originating in bulk-import are surfaced through `exportStatus` (`FAILED`) or as user-facing errors on create/download.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -131,6 +131,9 @@ type Query {
     @validateAdminUserAccess
     @cacheControl(scope: PRIVATE)
   getAccount: Account @validateAdminUserAccess @cacheControl(scope: PRIVATE)
+  exportStatus(exportId: String!): ExportStatusResult
+    @cacheControl(scope: PRIVATE)
+    @validateAdminUserAccess
 }
 
 type Account {
@@ -347,6 +350,9 @@ type Mutation {
     @withSession
     @withPermissions
     @validateAdminUserAccess(adminPermission: "B2B_ORGANIZATIONS_EDIT")
+  createExport(exportType: ExportType!): CreateExportResult
+    @cacheControl(scope: PRIVATE)
+    @validateAdminUserAccess
 }
 
 type SettingsResponse {
@@ -749,4 +755,31 @@ type DropdownValue {
 input DropdownValueInput {
   value: String
   label: String
+}
+
+enum ExportType {
+  organizations
+  cost_centers
+  members
+  addresses
+}
+
+enum ExportStatus {
+  IN_PROGRESS
+  COMPLETED
+  FAILED
+}
+
+type CreateExportResult {
+  exportId: String!
+}
+
+type ExportStatusResult {
+  exportId: String!
+  status: ExportStatus!
+  progressPercentage: Int
+  exportedRows: Int
+  linkToFile: String
+  lastUpdate: String
+  startDate: String
 }

--- a/manifest.json
+++ b/manifest.json
@@ -105,6 +105,13 @@
         "host": "b2b-bulk-import.vtexcommercestable.com.br",
         "path": "/api/b2b/*"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "s3.amazonaws.com",
+        "path": "*"
+      }
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/manifest.json
+++ b/manifest.json
@@ -98,6 +98,13 @@
         "host": "analytics.vtex.com",
         "path": "*"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "b2b-bulk-import.vtexcommercestable.com.br",
+        "path": "/api/b2b/*"
+      }
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/bulkExport.ts
+++ b/node/clients/bulkExport.ts
@@ -7,11 +7,24 @@ import type { ExportType } from '../utils/export/constants'
 
 const BULK_EXPORT_BASE_URL = 'http://b2b-bulk-import.vtexcommercestable.com.br'
 
+const normalizeDownloadUrl = (linkToFile: string) => {
+  const url = linkToFile.startsWith('http')
+    ? linkToFile
+    : `${BULK_EXPORT_BASE_URL}${linkToFile.startsWith('/') ? '' : '/'}${linkToFile}`
+
+  return url.replace(
+    /^https:\/\/([a-z0-9-]+(?:\.[a-z0-9-]+)*\.vtexcommercestable\.com\.br)/i,
+    'http://$1'
+  )
+}
+
 export interface BulkExportStatusResponse {
   exportId: string
   status: number
   progressPercentage?: number
+  percentage?: number | string
   exportedRows?: number
+  totalRows?: number
   linkToFile?: string
   lastUpdate?: string
   startDate?: string
@@ -47,6 +60,22 @@ const getReadableErrorMessage = (error: any, fallback: string) => {
   return fallback
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const isRetryableNetworkError = (error: any) => {
+  const message = String(error?.message ?? '')
+  const code = String(error?.code ?? '')
+
+  return (
+    message.includes('socket disconnected') ||
+    message.includes('ECONNRESET') ||
+    message.includes('ETIMEDOUT') ||
+    message.includes('ESOCKETTIMEDOUT') ||
+    code === 'ECONNRESET' ||
+    code === 'ETIMEDOUT'
+  )
+}
+
 export default class BulkExportClient extends ExternalClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(BULK_EXPORT_BASE_URL, ctx, {
@@ -55,7 +84,7 @@ export default class BulkExportClient extends ExternalClient {
         VtexIdclientAutCookie: getAuthToken(ctx),
         ...options?.headers,
       },
-      timeout: 60000,
+      timeout: 120000,
     })
   }
 
@@ -85,38 +114,92 @@ export default class BulkExportClient extends ExternalClient {
   public getExportStatus = async (
     exportId: string
   ): Promise<BulkExportStatusResponse> => {
-    try {
-      return await this.http.get<BulkExportStatusResponse>(
-        `/api/b2b/export/${encodeURIComponent(exportId)}?an=${encodeURIComponent(
-          this.context.account
-        )}`,
-        {
+    const path = `/api/b2b/export/${encodeURIComponent(exportId)}?an=${encodeURIComponent(
+      this.context.account
+    )}`
+    const url = `${BULK_EXPORT_BASE_URL}${path}`
+
+    console.log('[bulkExport.getExportStatus] start', {
+      account: this.context.account,
+      exportId,
+      url,
+    })
+
+    let lastError: any
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const response = await this.http.get<BulkExportStatusResponse>(path, {
           metric: 'bulk-export-status',
+        })
+
+        console.log('[bulkExport.getExportStatus] success', {
+          attempt,
+          exportId,
+          response,
+        })
+
+        return response
+      } catch (err) {
+        lastError = err
+
+        console.log('[bulkExport.getExportStatus] error', {
+          attempt,
+          code: err?.code,
+          exportId,
+          message: err?.message,
+          responseData: err?.response?.data,
+          responseStatus: err?.response?.status,
+          retryable: isRetryableNetworkError(err),
+          url,
+        })
+
+        if (attempt < 3 && isRetryableNetworkError(err)) {
+          await sleep(1000 * attempt)
+          continue
         }
-      )
-    } catch (error) {
-      throw new UserInputError(
-        getReadableErrorMessage(
-          error,
-          'Unable to retrieve export status. Please try again.'
-        )
-      )
+
+        break
+      }
     }
+
+    throw new UserInputError(
+      getReadableErrorMessage(
+        lastError,
+        'Unable to retrieve export status. Please try again.'
+      )
+    )
   }
 
   public downloadFile = async (linkToFile: string): Promise<Buffer> => {
-    const url = linkToFile.startsWith('http')
-      ? linkToFile
-      : `${BULK_EXPORT_BASE_URL}${linkToFile.startsWith('/') ? '' : '/'}${linkToFile}`
+    const url = normalizeDownloadUrl(linkToFile)
+    const isAbsoluteUrl = /^https?:\/\//i.test(url)
+
+    console.log('[bulkExport.downloadFile] start', {
+      isAbsoluteUrl,
+      url: url.slice(0, 120),
+    })
 
     try {
       const data = await this.http.get<ArrayBuffer>(url, {
+        baseURL: isAbsoluteUrl ? '' : undefined,
         metric: 'bulk-export-download',
         responseType: 'arraybuffer',
       })
 
+      console.log('[bulkExport.downloadFile] success', {
+        bytes: data.byteLength,
+      })
+
       return Buffer.from(data)
     } catch (error) {
+      console.log('[bulkExport.downloadFile] error', {
+        code: error?.code,
+        message: error?.message,
+        responseStatus: error?.response?.status,
+        url: url.slice(0, 120),
+      })
+
       throw new UserInputError(
         getReadableErrorMessage(
           error,

--- a/node/clients/bulkExport.ts
+++ b/node/clients/bulkExport.ts
@@ -117,13 +117,6 @@ export default class BulkExportClient extends ExternalClient {
     const path = `/api/b2b/export/${encodeURIComponent(exportId)}?an=${encodeURIComponent(
       this.context.account
     )}`
-    const url = `${BULK_EXPORT_BASE_URL}${path}`
-
-    console.log('[bulkExport.getExportStatus] start', {
-      account: this.context.account,
-      exportId,
-      url,
-    })
 
     let lastError: any
 
@@ -133,26 +126,9 @@ export default class BulkExportClient extends ExternalClient {
           metric: 'bulk-export-status',
         })
 
-        console.log('[bulkExport.getExportStatus] success', {
-          attempt,
-          exportId,
-          response,
-        })
-
         return response
       } catch (err) {
         lastError = err
-
-        console.log('[bulkExport.getExportStatus] error', {
-          attempt,
-          code: err?.code,
-          exportId,
-          message: err?.message,
-          responseData: err?.response?.data,
-          responseStatus: err?.response?.status,
-          retryable: isRetryableNetworkError(err),
-          url,
-        })
 
         if (attempt < 3 && isRetryableNetworkError(err)) {
           await sleep(1000 * attempt)
@@ -175,11 +151,6 @@ export default class BulkExportClient extends ExternalClient {
     const url = normalizeDownloadUrl(linkToFile)
     const isAbsoluteUrl = /^https?:\/\//i.test(url)
 
-    console.log('[bulkExport.downloadFile] start', {
-      isAbsoluteUrl,
-      url: url.slice(0, 120),
-    })
-
     try {
       const data = await this.http.get<ArrayBuffer>(url, {
         baseURL: isAbsoluteUrl ? '' : undefined,
@@ -187,19 +158,8 @@ export default class BulkExportClient extends ExternalClient {
         responseType: 'arraybuffer',
       })
 
-      console.log('[bulkExport.downloadFile] success', {
-        bytes: data.byteLength,
-      })
-
       return Buffer.from(data)
     } catch (error) {
-      console.log('[bulkExport.downloadFile] error', {
-        code: error?.code,
-        message: error?.message,
-        responseStatus: error?.response?.status,
-        url: url.slice(0, 120),
-      })
-
       throw new UserInputError(
         getReadableErrorMessage(
           error,

--- a/node/clients/bulkExport.ts
+++ b/node/clients/bulkExport.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { ExternalClient, UserInputError } from '@vtex/api'
+import FormData from 'form-data'
+
+import type { ExportType } from '../utils/export/constants'
+
+const BULK_EXPORT_BASE_URL = 'http://b2b-bulk-import.vtexcommercestable.com.br'
+
+export interface BulkExportStatusResponse {
+  exportId: string
+  status: number
+  progressPercentage?: number
+  exportedRows?: number
+  linkToFile?: string
+  lastUpdate?: string
+  startDate?: string
+}
+
+export interface CreateExportResponse {
+  exportId: string
+}
+
+const getAuthToken = (ctx: IOContext) =>
+  (ctx as IOContext & { adminUserAuthToken?: string }).adminUserAuthToken ??
+  ctx.authToken
+
+const getReadableErrorMessage = (error: any, fallback: string) => {
+  const data = error?.response?.data
+
+  if (typeof data === 'string' && data.trim()) {
+    return data
+  }
+
+  if (typeof data?.message === 'string' && data.message.trim()) {
+    return data.message
+  }
+
+  if (typeof data?.error === 'string' && data.error.trim()) {
+    return data.error
+  }
+
+  if (typeof error?.message === 'string' && error.message.trim()) {
+    return error.message
+  }
+
+  return fallback
+}
+
+export default class BulkExportClient extends ExternalClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(BULK_EXPORT_BASE_URL, ctx, {
+      ...options,
+      headers: {
+        VtexIdclientAutCookie: getAuthToken(ctx),
+        ...options?.headers,
+      },
+      timeout: 60000,
+    })
+  }
+
+  public createExport = async (
+    exportType: ExportType
+  ): Promise<CreateExportResponse> => {
+    const formData = new FormData()
+
+    formData.append('exportType', exportType)
+
+    try {
+      return await this.http.post<CreateExportResponse>(
+        `/api/b2b/export?an=${encodeURIComponent(this.context.account)}`,
+        formData,
+        {
+          headers: formData.getHeaders(),
+          metric: 'bulk-export-create',
+        }
+      )
+    } catch (error) {
+      throw new UserInputError(
+        getReadableErrorMessage(error, 'Unable to start export. Please try again.')
+      )
+    }
+  }
+
+  public getExportStatus = async (
+    exportId: string
+  ): Promise<BulkExportStatusResponse> => {
+    try {
+      return await this.http.get<BulkExportStatusResponse>(
+        `/api/b2b/export/${encodeURIComponent(exportId)}?an=${encodeURIComponent(
+          this.context.account
+        )}`,
+        {
+          metric: 'bulk-export-status',
+        }
+      )
+    } catch (error) {
+      throw new UserInputError(
+        getReadableErrorMessage(
+          error,
+          'Unable to retrieve export status. Please try again.'
+        )
+      )
+    }
+  }
+
+  public downloadFile = async (linkToFile: string): Promise<Buffer> => {
+    const url = linkToFile.startsWith('http')
+      ? linkToFile
+      : `${BULK_EXPORT_BASE_URL}${linkToFile.startsWith('/') ? '' : '/'}${linkToFile}`
+
+    try {
+      const data = await this.http.get<ArrayBuffer>(url, {
+        metric: 'bulk-export-download',
+        responseType: 'arraybuffer',
+      })
+
+      return Buffer.from(data)
+    } catch (error) {
+      throw new UserInputError(
+        getReadableErrorMessage(
+          error,
+          'Unable to download export file. Please try again.'
+        )
+      )
+    }
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -13,6 +13,7 @@ import IdentityClient from './IdentityClient'
 import Catalog from './catalog'
 import SellersClient from './sellers'
 import { AuditClient } from './audit'
+import BulkExportClient from './bulkExport'
 
 // Extend the default IOClients implementation with our own custom clients.
 export class Clients extends IOClients {
@@ -66,5 +67,9 @@ export class Clients extends IOClients {
 
   public get sellers() {
     return this.getOrSet('sellers', SellersClient)
+  }
+
+  public get bulkExport() {
+    return this.getOrSet('bulkExport', BulkExportClient)
   }
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -23,6 +23,10 @@ const clients: ClientsConfig<Clients> = {
   // We pass our custom implementation of the clients bag, containing the Status client.
   implementation: Clients,
   options: {
+    bulkExport: {
+      retries: 4,
+      timeout: 120000,
+    },
     // All IO Clients will be initialized with these options, unless otherwise specified.
     default: {
       retries: 2,

--- a/node/package.json
+++ b/node/package.json
@@ -6,6 +6,8 @@
     "@vtex/api": "6.50.1",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
+    "exceljs": "^4.4.0",
+    "form-data": "^4.0.4",
     "graphql": "^14.5.0",
     "graphql-tag": "^2.12.6",
     "graphql-tools": "^4.0.6",

--- a/node/resolvers/Mutations/Export.ts
+++ b/node/resolvers/Mutations/Export.ts
@@ -1,0 +1,31 @@
+import { UserInputError } from '@vtex/api'
+
+import type { ExportMetadata, ExportType } from '../../utils/export/constants'
+import { EXPORT_VBASE_BUCKET } from '../../utils/export/constants'
+
+const Export = {
+  createExport: async (
+    _: void,
+    { exportType }: { exportType: ExportType },
+    ctx: Context
+  ) => {
+    const { exportId } = await ctx.clients.bulkExport.createExport(exportType)
+
+    if (!exportId) {
+      throw new UserInputError('Unable to start export. Please try again.')
+    }
+
+    const metadata: ExportMetadata = {
+      convertedAt: '',
+      exportId,
+      exportType,
+      filename: '',
+    }
+
+    await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
+
+    return { exportId }
+  },
+}
+
+export default Export

--- a/node/resolvers/Mutations/Export.ts
+++ b/node/resolvers/Mutations/Export.ts
@@ -2,6 +2,7 @@ import { UserInputError } from '@vtex/api'
 
 import type { ExportMetadata, ExportType } from '../../utils/export/constants'
 import { EXPORT_VBASE_BUCKET } from '../../utils/export/constants'
+import { countExportTotalRows } from '../../utils/export/countExportTotalRows'
 
 const Export = {
   createExport: async (
@@ -9,10 +10,28 @@ const Export = {
     { exportType }: { exportType: ExportType },
     ctx: Context
   ) => {
-    const { exportId } = await ctx.clients.bulkExport.createExport(exportType)
+    const {
+      clients: { bulkExport, vbase },
+      vtex: { logger },
+    } = ctx
+
+    const { exportId } = await bulkExport.createExport(exportType)
 
     if (!exportId) {
       throw new UserInputError('Unable to start export. Please try again.')
+    }
+
+    let totalRows: number | null = null
+
+    try {
+      totalRows = await countExportTotalRows(exportType, ctx)
+    } catch (error) {
+      logger.warn({
+        error,
+        exportId,
+        exportType,
+        message: 'createExport.countTotalRowsFailed',
+      })
     }
 
     const metadata: ExportMetadata = {
@@ -20,9 +39,10 @@ const Export = {
       exportId,
       exportType,
       filename: '',
+      totalRows,
     }
 
-    await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
+    await vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
 
     return { exportId }
   },

--- a/node/resolvers/Queries/Export.ts
+++ b/node/resolvers/Queries/Export.ts
@@ -1,14 +1,15 @@
-import { Readable } from 'stream'
-
-import type { ExportMetadata, ExportType } from '../../utils/export/constants'
+import type { BulkExportStatusResponse } from '../../clients/bulkExport'
 import {
   buildExportDownloadUrl,
   EXPORT_STATUS,
   EXPORT_STATUS_GRAPHQL,
-  EXPORT_VBASE_BUCKET,
-  getExportFilePath,
 } from '../../utils/export/constants'
-import { convertXlsxToCsv } from '../../utils/export/csvConverter'
+import { getExportMetadata } from '../../utils/export/ensureConvertedExport'
+import {
+  getCachedStatusSnapshot,
+  saveStatusSnapshot,
+  snapshotToStatusResponse,
+} from '../../utils/export/exportStatusCache'
 
 const getRequestHost = (ctx: Context) => {
   const forwardedHost = ctx.headers['x-forwarded-host'] as string | undefined
@@ -16,50 +17,74 @@ const getRequestHost = (ctx: Context) => {
   return ctx.vtex.host || forwardedHost || `${ctx.vtex.account}.myvtex.com`
 }
 
-const getExportMetadata = async (ctx: Context, exportId: string) => {
-  try {
-    return await ctx.clients.vbase.getJSON<ExportMetadata>(
-      EXPORT_VBASE_BUCKET,
-      exportId
-    )
-  } catch (error) {
-    const { data } = (error as any).response ?? {}
-
-    if (data?.code === 'FileNotFound') {
-      return null
-    }
-
-    throw error
+const toGraphQLInt = (value: number | null | undefined) => {
+  if (value == null || Number.isNaN(Number(value))) {
+    return null
   }
+
+  return Math.round(Number(value))
 }
 
-const hasConvertedFile = (metadata: ExportMetadata | null) =>
-  Boolean(metadata?.convertedAt && metadata?.filename)
-
-const storeConvertedExport = async (
-  ctx: Context,
-  exportId: string,
-  exportType: ExportType,
-  csvBuffer: Buffer,
-  filename: string
-) => {
-  const filePath = getExportFilePath(exportId)
-  const metadata: ExportMetadata = {
-    convertedAt: new Date().toISOString(),
-    exportId,
-    exportType,
-    filename,
+const parseNumericValue = (value: unknown) => {
+  if (value == null || value === '') {
+    return null
   }
 
-  await ctx.clients.vbase.saveFile(
-    EXPORT_VBASE_BUCKET,
-    filePath,
-    Readable.from(csvBuffer),
-    true
-  )
-  await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
+  const parsed = Number(value)
 
-  return metadata
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+const resolveProgressPercentage = (
+  statusResponse: {
+    exportedRows?: number
+    percentage?: number | string
+    progressPercentage?: number
+    totalRows?: number
+  },
+  storedTotalRows?: number | null
+) => {
+  const rawResponse = statusResponse as typeof statusResponse &
+    Record<string, unknown>
+
+  let progress =
+    parseNumericValue(statusResponse.progressPercentage) ??
+    parseNumericValue(statusResponse.percentage) ??
+    parseNumericValue(rawResponse.ProgressPercentage) ??
+    parseNumericValue(rawResponse.Percentage)
+
+  if (progress != null && progress > 0 && progress <= 1) {
+    progress = Math.round(progress * 100)
+  } else if (progress != null) {
+    progress = Math.round(progress)
+  }
+
+  const exportedRows = parseNumericValue(statusResponse.exportedRows)
+  const totalRows =
+    parseNumericValue(statusResponse.totalRows) ??
+    parseNumericValue(rawResponse.TotalRows) ??
+    parseNumericValue(rawResponse.totalExportedRows) ??
+    parseNumericValue(rawResponse.TotalExportedRows) ??
+    storedTotalRows ??
+    null
+
+  if (
+    (progress == null || progress === 0) &&
+    exportedRows != null &&
+    totalRows != null &&
+    totalRows > 0
+  ) {
+    progress = Math.round((exportedRows / totalRows) * 100)
+  }
+
+  if (
+    progress == null ||
+    (progress === 0 && exportedRows != null && exportedRows > 0)
+  ) {
+    return null
+  }
+
+  return Math.min(100, Math.max(0, progress))
 }
 
 const Export = {
@@ -73,7 +98,30 @@ const Export = {
       vtex: { logger },
     } = ctx
 
-    const statusResponse = await bulkExport.getExportStatus(exportId)
+    console.log('[exportStatus] start', { exportId })
+
+    const metadata = await getExportMetadata(ctx, exportId)
+    let statusResponse: BulkExportStatusResponse
+
+    try {
+      statusResponse = await bulkExport.getExportStatus(exportId)
+    } catch (error) {
+      const snapshot = getCachedStatusSnapshot(ctx, exportId, metadata)
+
+      if (snapshot) {
+        logger.warn({
+          error,
+          exportId,
+          message: 'exportStatus.usingCachedSnapshot',
+        })
+        statusResponse = snapshotToStatusResponse(exportId, snapshot)
+      } else {
+        throw error
+      }
+    }
+
+    await saveStatusSnapshot(ctx, exportId, statusResponse, metadata)
+
     const mappedStatus =
       EXPORT_STATUS_GRAPHQL[
         statusResponse.status as keyof typeof EXPORT_STATUS_GRAPHQL
@@ -81,34 +129,19 @@ const Export = {
 
     const result = {
       exportId: statusResponse.exportId ?? exportId,
-      exportedRows: statusResponse.exportedRows ?? null,
+      exportedRows: toGraphQLInt(statusResponse.exportedRows),
       lastUpdate: statusResponse.lastUpdate ?? null,
       linkToFile: null as string | null,
-      progressPercentage: statusResponse.progressPercentage ?? null,
+      progressPercentage: resolveProgressPercentage(
+        statusResponse,
+        metadata?.totalRows
+      ),
       startDate: statusResponse.startDate ?? null,
       status: mappedStatus,
     }
 
     if (statusResponse.status !== EXPORT_STATUS.COMPLETED) {
-      return result
-    }
-
-    const metadata = await getExportMetadata(ctx, exportId)
-
-    if (hasConvertedFile(metadata)) {
-      result.linkToFile = buildExportDownloadUrl(
-        getRequestHost(ctx),
-        exportId
-      )
-
-      return result
-    }
-
-    if (!statusResponse.linkToFile) {
-      logger.warn({
-        exportId,
-        message: 'exportStatus.missingLinkToFile',
-      })
+      console.log('[exportStatus] result', { exportId, result })
 
       return result
     }
@@ -122,27 +155,18 @@ const Export = {
       return result
     }
 
-    const xlsxBuffer = await bulkExport.downloadFile(statusResponse.linkToFile)
-    const { buffer, filename } = await convertXlsxToCsv(
-      xlsxBuffer,
-      metadata.exportType
-    )
+    if (!statusResponse.linkToFile) {
+      logger.warn({
+        exportId,
+        message: 'exportStatus.missingLinkToFile',
+      })
 
-    await storeConvertedExport(
-      ctx,
-      exportId,
-      metadata.exportType,
-      buffer,
-      filename
-    )
+      return result
+    }
 
     result.linkToFile = buildExportDownloadUrl(getRequestHost(ctx), exportId)
 
-    logger.info({
-      exportId,
-      filename,
-      message: 'exportStatus.converted',
-    })
+    console.log('[exportStatus] result', { exportId, result })
 
     return result
   },

--- a/node/resolvers/Queries/Export.ts
+++ b/node/resolvers/Queries/Export.ts
@@ -98,8 +98,6 @@ const Export = {
       vtex: { logger },
     } = ctx
 
-    console.log('[exportStatus] start', { exportId })
-
     const metadata = await getExportMetadata(ctx, exportId)
     let statusResponse: BulkExportStatusResponse
 
@@ -141,8 +139,6 @@ const Export = {
     }
 
     if (statusResponse.status !== EXPORT_STATUS.COMPLETED) {
-      console.log('[exportStatus] result', { exportId, result })
-
       return result
     }
 
@@ -165,8 +161,6 @@ const Export = {
     }
 
     result.linkToFile = buildExportDownloadUrl(getRequestHost(ctx), exportId)
-
-    console.log('[exportStatus] result', { exportId, result })
 
     return result
   },

--- a/node/resolvers/Queries/Export.ts
+++ b/node/resolvers/Queries/Export.ts
@@ -1,0 +1,151 @@
+import { Readable } from 'stream'
+
+import type { ExportMetadata, ExportType } from '../../utils/export/constants'
+import {
+  buildExportDownloadUrl,
+  EXPORT_STATUS,
+  EXPORT_STATUS_GRAPHQL,
+  EXPORT_VBASE_BUCKET,
+  getExportFilePath,
+} from '../../utils/export/constants'
+import { convertXlsxToCsv } from '../../utils/export/csvConverter'
+
+const getRequestHost = (ctx: Context) => {
+  const forwardedHost = ctx.headers['x-forwarded-host'] as string | undefined
+
+  return ctx.vtex.host || forwardedHost || `${ctx.vtex.account}.myvtex.com`
+}
+
+const getExportMetadata = async (ctx: Context, exportId: string) => {
+  try {
+    return await ctx.clients.vbase.getJSON<ExportMetadata>(
+      EXPORT_VBASE_BUCKET,
+      exportId
+    )
+  } catch (error) {
+    const { data } = (error as any).response ?? {}
+
+    if (data?.code === 'FileNotFound') {
+      return null
+    }
+
+    throw error
+  }
+}
+
+const hasConvertedFile = (metadata: ExportMetadata | null) =>
+  Boolean(metadata?.convertedAt && metadata?.filename)
+
+const storeConvertedExport = async (
+  ctx: Context,
+  exportId: string,
+  exportType: ExportType,
+  csvBuffer: Buffer,
+  filename: string
+) => {
+  const filePath = getExportFilePath(exportId)
+  const metadata: ExportMetadata = {
+    convertedAt: new Date().toISOString(),
+    exportId,
+    exportType,
+    filename,
+  }
+
+  await ctx.clients.vbase.saveFile(
+    EXPORT_VBASE_BUCKET,
+    filePath,
+    Readable.from(csvBuffer),
+    true
+  )
+  await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
+
+  return metadata
+}
+
+const Export = {
+  exportStatus: async (
+    _: void,
+    { exportId }: { exportId: string },
+    ctx: Context
+  ) => {
+    const {
+      clients: { bulkExport },
+      vtex: { logger },
+    } = ctx
+
+    const statusResponse = await bulkExport.getExportStatus(exportId)
+    const mappedStatus =
+      EXPORT_STATUS_GRAPHQL[
+        statusResponse.status as keyof typeof EXPORT_STATUS_GRAPHQL
+      ] ?? 'FAILED'
+
+    const result = {
+      exportId: statusResponse.exportId ?? exportId,
+      exportedRows: statusResponse.exportedRows ?? null,
+      lastUpdate: statusResponse.lastUpdate ?? null,
+      linkToFile: null as string | null,
+      progressPercentage: statusResponse.progressPercentage ?? null,
+      startDate: statusResponse.startDate ?? null,
+      status: mappedStatus,
+    }
+
+    if (statusResponse.status !== EXPORT_STATUS.COMPLETED) {
+      return result
+    }
+
+    const metadata = await getExportMetadata(ctx, exportId)
+
+    if (hasConvertedFile(metadata)) {
+      result.linkToFile = buildExportDownloadUrl(
+        getRequestHost(ctx),
+        exportId
+      )
+
+      return result
+    }
+
+    if (!statusResponse.linkToFile) {
+      logger.warn({
+        exportId,
+        message: 'exportStatus.missingLinkToFile',
+      })
+
+      return result
+    }
+
+    if (!metadata?.exportType) {
+      logger.warn({
+        exportId,
+        message: 'exportStatus.missingExportType',
+      })
+
+      return result
+    }
+
+    const xlsxBuffer = await bulkExport.downloadFile(statusResponse.linkToFile)
+    const { buffer, filename } = await convertXlsxToCsv(
+      xlsxBuffer,
+      metadata.exportType
+    )
+
+    await storeConvertedExport(
+      ctx,
+      exportId,
+      metadata.exportType,
+      buffer,
+      filename
+    )
+
+    result.linkToFile = buildExportDownloadUrl(getRequestHost(ctx), exportId)
+
+    logger.info({
+      exportId,
+      filename,
+      message: 'exportStatus.converted',
+    })
+
+    return result
+  },
+}
+
+export default Export

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -247,12 +247,6 @@ const Index = {
       metadata?.filename || `b2b-export-${exportId as string}.csv`
 
     try {
-      console.log('[exportDownload] fetching file', {
-        exportId,
-        filename,
-        path: getExportFilePath(exportId as string),
-      })
-
       const fileStream = await vbase.getFileStream(
         EXPORT_VBASE_BUCKET,
         getExportFilePath(exportId as string)
@@ -271,10 +265,6 @@ const Index = {
         error,
         exportId,
         message: 'exportDownload.file-error',
-      })
-      console.log('[exportDownload] file-error', {
-        error,
-        exportId,
       })
       throw new UserInputError('Export file not found or expired')
     }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -9,6 +9,7 @@ import {
   EXPORT_VBASE_BUCKET,
   getExportFilePath,
 } from '../../utils/export/constants'
+import { ensureExportIsConverted } from '../../utils/export/ensureConvertedExport'
 import { validateAdminToken } from '../directives/helper'
 
 const getUserAndPermissions = async (ctx: Context) => {
@@ -232,23 +233,27 @@ const Index = {
     let metadata: ExportMetadata | null = null
 
     try {
-      metadata = await vbase.getJSON<ExportMetadata>(
-        EXPORT_VBASE_BUCKET,
-        exportId as string
-      )
+      metadata = await ensureExportIsConverted(ctx, exportId as string)
     } catch (error) {
       logger.error({
         error,
         exportId,
-        message: 'exportDownload.metadata-error',
+        message: 'exportDownload.convert-error',
       })
+      throw new UserInputError('Unable to prepare export file for download')
     }
 
     const filename =
       metadata?.filename || `b2b-export-${exportId as string}.csv`
 
     try {
-      const fileStream = await vbase.getFile(
+      console.log('[exportDownload] fetching file', {
+        exportId,
+        filename,
+        path: getExportFilePath(exportId as string),
+      })
+
+      const fileStream = await vbase.getFileStream(
         EXPORT_VBASE_BUCKET,
         getExportFilePath(exportId as string)
       )
@@ -266,6 +271,10 @@ const Index = {
         error,
         exportId,
         message: 'exportDownload.file-error',
+      })
+      console.log('[exportDownload] file-error', {
+        error,
+        exportId,
       })
       throw new UserInputError('Export file not found or expired')
     }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -4,6 +4,12 @@ import {
   COST_CENTER_DATA_ENTITY,
   ORGANIZATION_DATA_ENTITY,
 } from '../../mdSchema'
+import type { ExportMetadata } from '../../utils/export/constants'
+import {
+  EXPORT_VBASE_BUCKET,
+  getExportFilePath,
+} from '../../utils/export/constants'
+import { validateAdminToken } from '../directives/helper'
 
 const getUserAndPermissions = async (ctx: Context) => {
   const {
@@ -195,6 +201,74 @@ const Index = {
     ctx.set('Cache-Control', 'no-cache, no-store')
 
     ctx.response.body = response
+  },
+  exportDownload: async (ctx: Context) => {
+    const {
+      vtex: {
+        adminUserAuthToken,
+        authToken,
+        route: {
+          params: { exportId },
+        },
+        logger,
+      },
+      clients: { vbase },
+    } = ctx
+
+    const token = (adminUserAuthToken || authToken) as string
+    const { hasValidAdminToken, hasValidAdminRole } = await validateAdminToken(
+      ctx,
+      token
+    )
+
+    if (!hasValidAdminToken || !hasValidAdminRole) {
+      throw new ForbiddenError('Access denied')
+    }
+
+    if (!exportId) {
+      throw new UserInputError('Export ID is required')
+    }
+
+    let metadata: ExportMetadata | null = null
+
+    try {
+      metadata = await vbase.getJSON<ExportMetadata>(
+        EXPORT_VBASE_BUCKET,
+        exportId as string
+      )
+    } catch (error) {
+      logger.error({
+        error,
+        exportId,
+        message: 'exportDownload.metadata-error',
+      })
+    }
+
+    const filename =
+      metadata?.filename || `b2b-export-${exportId as string}.csv`
+
+    try {
+      const fileStream = await vbase.getFile(
+        EXPORT_VBASE_BUCKET,
+        getExportFilePath(exportId as string)
+      )
+
+      ctx.set('Content-Type', 'text/csv; charset=utf-8')
+      ctx.set(
+        'Content-Disposition',
+        `attachment; filename="${filename.replace(/"/g, '')}"`
+      )
+      ctx.set('Cache-Control', 'no-cache, no-store')
+      ctx.response.body = fileStream
+      ctx.response.status = 200
+    } catch (error) {
+      logger.error({
+        error,
+        exportId,
+        message: 'exportDownload.file-error',
+      })
+      throw new UserInputError('Export file not found or expired')
+    }
   },
   order: async (ctx: Context) => {
     const order = await getOrder(ctx)

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -8,11 +8,13 @@ import {
   role,
 } from './fieldResolvers'
 import CostCentersMutation from './Mutations/CostCenters'
+import ExportMutation from './Mutations/Export'
 import MarketingTagsMutation from './Mutations/MarketingTags'
 import OrganizationsMutation from './Mutations/Organizations'
 import SettingsMutation from './Mutations/Settings'
 import UsersMutation from './Mutations/Users'
 import CostCentersQuery from './Queries/CostCenters'
+import ExportQuery from './Queries/Export'
 import MarketingTagsQuery from './Queries/MarketingTags'
 import OrganizationsQuery from './Queries/Organizations'
 import SettingsQuery from './Queries/Settings'
@@ -33,6 +35,7 @@ export const resolvers = {
   },
   Mutation: {
     ...CostCentersMutation,
+    ...ExportMutation,
     ...MarketingTagsMutation,
     ...OrganizationsMutation,
     ...SettingsMutation,
@@ -40,6 +43,7 @@ export const resolvers = {
   },
   Query: {
     ...CostCentersQuery,
+    ...ExportQuery,
     ...MarketingTagsQuery,
     ...OrganizationsQuery,
     ...SettingsQuery,

--- a/node/service.json
+++ b/node/service.json
@@ -28,6 +28,10 @@
       "path": "/_v/private/b2b/checkout/pub/orders/:orderId/user-cancel-request",
       "public": true
     },
+    "exportDownload": {
+      "path": "/_v/private/b2b/export/:exportId",
+      "public": true
+    },
     "__graphql": {
       "path": "/_v/graphql",
       "policies": [

--- a/node/service.json
+++ b/node/service.json
@@ -2,7 +2,7 @@
   "stack": "nodejs",
   "memory": 1024,
   "ttl": 300,
-  "timeout": 60,
+  "timeout": 120,
   "cpu": {
     "type": "shared",
     "value": 5,

--- a/node/utils/export/columnMappings.ts
+++ b/node/utils/export/columnMappings.ts
@@ -1,0 +1,130 @@
+import type { ExportType } from './constants'
+
+export type ColumnTransform = 'array' | 'json' | 'default'
+
+export interface ColumnDef {
+  header: string
+  field: string
+  transform?: ColumnTransform
+}
+
+const normalizeHeader = (header: string) =>
+  header.trim().toLowerCase().replace(/\s+/g, ' ')
+
+const buildAliasMap = (aliases: Record<string, string>) => {
+  const map: Record<string, string> = {}
+
+  Object.entries(aliases).forEach(([alias, field]) => {
+    map[normalizeHeader(alias)] = field
+  })
+
+  return map
+}
+
+export const ORGANIZATION_COLUMNS: ColumnDef[] = [
+  { header: 'Id', field: 'id' },
+  { header: 'Name', field: 'name' },
+  { header: 'Trade Name', field: 'tradeName' },
+  { header: 'Collections', field: 'collections', transform: 'array' },
+  { header: 'Price Tables', field: 'priceTables', transform: 'array' },
+  { header: 'Payment Terms', field: 'paymentTerms', transform: 'array' },
+  { header: 'Sales Channel', field: 'salesChannel' },
+  { header: 'Sellers', field: 'sellers', transform: 'array' },
+  { header: 'Status', field: 'status' },
+  { header: 'Created', field: 'created' },
+  { header: 'Custom Fields', field: 'customFields', transform: 'json' },
+]
+
+export const COST_CENTER_COLUMNS: ColumnDef[] = [
+  { header: 'Organization Id', field: 'organization' },
+  { header: 'Cost Center Id', field: 'id' },
+  { header: 'Name', field: 'name' },
+  { header: 'Payment Terms', field: 'paymentTerms', transform: 'array' },
+  { header: 'Phone Number', field: 'phoneNumber' },
+  { header: 'Business Document', field: 'businessDocument' },
+  { header: 'State Registration', field: 'stateRegistration' },
+  { header: 'Sellers', field: 'sellers', transform: 'array' },
+  { header: 'Custom Fields', field: 'customFields', transform: 'json' },
+]
+
+const ORGANIZATION_HEADER_ALIASES = buildAliasMap({
+  collections: 'collections',
+  created: 'created',
+  'custom fields': 'customFields',
+  customfields: 'customFields',
+  id: 'id',
+  name: 'name',
+  'payment terms': 'paymentTerms',
+  paymentterms: 'paymentTerms',
+  'price tables': 'priceTables',
+  pricetables: 'priceTables',
+  'sales channel': 'salesChannel',
+  saleschannel: 'salesChannel',
+  sellers: 'sellers',
+  status: 'status',
+  'trade name': 'tradeName',
+  tradename: 'tradeName',
+})
+
+const COST_CENTER_HEADER_ALIASES = buildAliasMap({
+  'business document': 'businessDocument',
+  businessdocument: 'businessDocument',
+  'cost center id': 'id',
+  costcenterid: 'id',
+  'custom fields': 'customFields',
+  customfields: 'customFields',
+  id: 'id',
+  name: 'name',
+  organization: 'organization',
+  'organization id': 'organization',
+  organizationid: 'organization',
+  'payment terms': 'paymentTerms',
+  paymentterms: 'paymentTerms',
+  'phone number': 'phoneNumber',
+  phonenumber: 'phoneNumber',
+  sellers: 'sellers',
+  'state registration': 'stateRegistration',
+  stateregistration: 'stateRegistration',
+})
+
+const MAPPED_EXPORT_TYPES: ExportType[] = ['organizations', 'cost_centers']
+
+export const isMappedExportType = (exportType: ExportType) =>
+  MAPPED_EXPORT_TYPES.includes(exportType)
+
+export const getColumnMapping = (
+  exportType: ExportType
+): { columns: ColumnDef[]; headerAliases: Record<string, string> } | null => {
+  if (exportType === 'organizations') {
+    return {
+      columns: ORGANIZATION_COLUMNS,
+      headerAliases: ORGANIZATION_HEADER_ALIASES,
+    }
+  }
+
+  if (exportType === 'cost_centers') {
+    return {
+      columns: COST_CENTER_COLUMNS,
+      headerAliases: COST_CENTER_HEADER_ALIASES,
+    }
+  }
+
+  return null
+}
+
+export const mapRowToFields = (
+  rawRow: Record<string, unknown>,
+  headerAliases: Record<string, string>
+) => {
+  const mappedRow: Record<string, unknown> = {}
+
+  Object.entries(rawRow).forEach(([header, value]) => {
+    const field = headerAliases[normalizeHeader(header)]
+
+    if (field) {
+      mappedRow[field] = value
+    }
+  })
+
+  return mappedRow
+}

--- a/node/utils/export/constants.ts
+++ b/node/utils/export/constants.ts
@@ -1,5 +1,7 @@
 export const EXPORT_VBASE_BUCKET = 'b2b_exports'
 
+export const EXPORT_CSV_VBASE_TTL_SECONDS = 300
+
 export const UTF8_BOM = '\uFEFF'
 
 export const EXPORT_STATUS = {
@@ -20,11 +22,22 @@ export type ExportType =
   | 'members'
   | 'addresses'
 
+export interface ExportStatusSnapshot {
+  capturedAt: string
+  exportedRows?: number | null
+  lastUpdate?: string | null
+  progressPercentage?: number | null
+  startDate?: string | null
+  status: number
+}
+
 export interface ExportMetadata {
+  convertedAt: string
   exportId: string
   exportType: ExportType
   filename: string
-  convertedAt: string
+  lastStatusSnapshot?: ExportStatusSnapshot
+  totalRows?: number | null
 }
 
 export const getExportFilePath = (exportId: string) => `${exportId}.csv`

--- a/node/utils/export/constants.ts
+++ b/node/utils/export/constants.ts
@@ -1,0 +1,39 @@
+export const EXPORT_VBASE_BUCKET = 'b2b_exports'
+
+export const UTF8_BOM = '\uFEFF'
+
+export const EXPORT_STATUS = {
+  COMPLETED: 1,
+  FAILED: 2,
+  IN_PROGRESS: 0,
+} as const
+
+export const EXPORT_STATUS_GRAPHQL = {
+  0: 'IN_PROGRESS',
+  1: 'COMPLETED',
+  2: 'FAILED',
+} as const
+
+export type ExportType =
+  | 'organizations'
+  | 'cost_centers'
+  | 'members'
+  | 'addresses'
+
+export interface ExportMetadata {
+  exportId: string
+  exportType: ExportType
+  filename: string
+  convertedAt: string
+}
+
+export const getExportFilePath = (exportId: string) => `${exportId}.csv`
+
+export const buildExportFilename = (exportType: ExportType) => {
+  const date = new Date().toISOString().slice(0, 10)
+
+  return `b2b-export-${exportType}-${date}.csv`
+}
+
+export const buildExportDownloadUrl = (host: string, exportId: string) =>
+  `https://${host}/_v/private/b2b/export/${exportId}`

--- a/node/utils/export/countExportTotalRows.ts
+++ b/node/utils/export/countExportTotalRows.ts
@@ -1,0 +1,116 @@
+import {
+  COST_CENTER_DATA_ENTITY,
+  COST_CENTER_SCHEMA_VERSION,
+  ORGANIZATION_DATA_ENTITY,
+  ORGANIZATION_SCHEMA_VERSION,
+} from '../../mdSchema'
+import type { ExportType } from './constants'
+
+interface CostCenterAddressScrollItem {
+  addresses?: unknown[]
+}
+
+const countMasterDataTotal = async (
+  ctx: Context,
+  dataEntity: string,
+  schema: string
+) => {
+  const result = await ctx.clients.masterdata.searchDocumentsWithPaginationInfo(
+    {
+      dataEntity,
+      fields: ['id'],
+      pagination: { page: 1, pageSize: 1 },
+      schema,
+    }
+  )
+
+  return result.pagination?.total ?? null
+}
+
+const countAddressesTotal = async (ctx: Context) => {
+  let total = 0
+  let token: string | undefined
+  let hasMore = true
+
+  while (hasMore) {
+    const {
+      mdToken,
+      data,
+    } = (await ctx.clients.masterdata.scrollDocuments({
+      dataEntity: COST_CENTER_DATA_ENTITY,
+      fields: ['addresses'],
+      mdToken: token,
+      schema: COST_CENTER_SCHEMA_VERSION,
+      size: 100,
+    })) as unknown as {
+      mdToken?: string
+      data: CostCenterAddressScrollItem[]
+    }
+
+    if (!data.length && token) {
+      hasMore = false
+    }
+
+    if (!token && mdToken) {
+      token = mdToken
+    }
+
+    data.forEach((costCenter) => {
+      total += costCenter.addresses?.length ?? 0
+    })
+
+    if (!mdToken || !data.length) {
+      hasMore = false
+    }
+  }
+
+  return total || null
+}
+
+export const countExportTotalRows = async (
+  exportType: ExportType,
+  ctx: Context
+): Promise<number | null> => {
+  switch (exportType) {
+    case 'organizations':
+      return countMasterDataTotal(
+        ctx,
+        ORGANIZATION_DATA_ENTITY,
+        ORGANIZATION_SCHEMA_VERSION
+      )
+
+    case 'cost_centers':
+      return countMasterDataTotal(
+        ctx,
+        COST_CENTER_DATA_ENTITY,
+        COST_CENTER_SCHEMA_VERSION
+      )
+
+    case 'members': {
+      try {
+        const result = await ctx.clients.storefrontPermissions.listUsersPaginated(
+          {
+            page: 1,
+            pageSize: 1,
+          }
+        )
+
+        const total = result?.data?.listUsersPaginated?.pagination?.total
+
+        return total != null ? total : null
+      } catch {
+        return null
+      }
+    }
+
+    case 'addresses':
+      try {
+        return await countAddressesTotal(ctx)
+      } catch {
+        return null
+      }
+
+    default:
+      return null
+  }
+}

--- a/node/utils/export/csvConverter.test.ts
+++ b/node/utils/export/csvConverter.test.ts
@@ -1,0 +1,160 @@
+import ExcelJS from 'exceljs'
+
+import {
+  COST_CENTER_COLUMNS,
+  ORGANIZATION_COLUMNS,
+} from './columnMappings'
+import { UTF8_BOM } from './constants'
+import {
+  buildCsvContent,
+  convertXlsxToCsv,
+  escapeCsvField,
+  rowsToCsvBuffer,
+  serializeCellValue,
+} from './csvConverter'
+
+const createWorkbookBuffer = async (
+  headers: string[],
+  rows: unknown[][]
+) => {
+  const workbook = new ExcelJS.Workbook()
+  const worksheet = workbook.addWorksheet('Export')
+
+  worksheet.addRow(headers)
+  rows.forEach((row) => worksheet.addRow(row))
+
+  const buffer = await workbook.xlsx.writeBuffer()
+
+  return Buffer.from(buffer)
+}
+
+describe('csvConverter', () => {
+  describe('escapeCsvField', () => {
+    it('escapes commas and quotes', () => {
+      expect(escapeCsvField('hello, world')).toBe('"hello, world"')
+      expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""')
+    })
+
+    it('returns plain values unchanged', () => {
+      expect(escapeCsvField('simple')).toBe('simple')
+    })
+  })
+
+  describe('serializeCellValue', () => {
+    it('joins arrays with pipe', () => {
+      expect(serializeCellValue(['a', 'b'], 'array')).toBe('a|b')
+    })
+
+    it('stringifies custom fields as JSON', () => {
+      expect(
+        serializeCellValue([{ name: 'field', value: '1' }], 'json')
+      ).toBe('[{"name":"field","value":"1"}]')
+    })
+  })
+
+  describe('buildCsvContent', () => {
+    it('includes UTF-8 BOM', () => {
+      const content = buildCsvContent(['Name'], [{ Name: 'Acme' }], 'members')
+
+      expect(content.startsWith(UTF8_BOM)).toBe(true)
+    })
+
+    it('normalizes organizations columns even when xlsx omits fields', () => {
+      const content = buildCsvContent(
+        ['Id', 'Name', 'Trade Name', 'Collections'],
+        [
+          {
+            Collections: ['col-a', 'col-b'],
+            Id: 'org-1',
+            Name: 'Acme',
+            'Trade Name': 'Acme LLC',
+          },
+        ],
+        'organizations'
+      )
+
+      ORGANIZATION_COLUMNS.forEach((column) => {
+        expect(content).toContain(column.header)
+      })
+
+      expect(content).toContain('col-a|col-b')
+      expect(content).toContain('Created')
+      expect(content).toContain('Custom Fields')
+    })
+
+    it('normalizes cost_centers columns including missing xlsx fields', () => {
+      const content = buildCsvContent(
+        ['Organization Id', 'Cost Center Id', 'Name'],
+        [
+          {
+            'Cost Center Id': 'cc-1',
+            Name: 'HQ',
+            'Organization Id': 'org-1',
+          },
+        ],
+        'cost_centers'
+      )
+
+      COST_CENTER_COLUMNS.forEach((column) => {
+        expect(content).toContain(column.header)
+      })
+
+      expect(content).toContain('State Registration')
+      expect(content).toContain('Sellers')
+      expect(content).toContain('Custom Fields')
+    })
+
+    it('keeps members headers as passthrough', () => {
+      const content = buildCsvContent(
+        ['Email', 'Role'],
+        [{ Email: 'user@example.com', Role: 'buyer' }],
+        'members'
+      )
+
+      expect(content).toContain('Email,Role')
+      expect(content).not.toContain('Custom Fields')
+    })
+
+    it('keeps addresses headers as passthrough', () => {
+      const content = buildCsvContent(
+        ['Street', 'City'],
+        [{ Street: 'Main', City: 'SP' }],
+        'addresses'
+      )
+
+      expect(content).toContain('Street,City')
+    })
+  })
+
+  describe('convertXlsxToCsv', () => {
+    it('converts xlsx buffer to csv with BOM', async () => {
+      const xlsxBuffer = await createWorkbookBuffer(
+        ['Id', 'Name', 'Collections'],
+        [['org-1', 'Acme', 'col-a|col-b']]
+      )
+
+      const { buffer, filename } = await convertXlsxToCsv(
+        xlsxBuffer,
+        'organizations'
+      )
+      const content = buffer.toString('utf8')
+
+      expect(filename).toMatch(/^b2b-export-organizations-\d{4}-\d{2}-\d{2}\.csv$/)
+      expect(content.startsWith(UTF8_BOM)).toBe(true)
+      expect(content).toContain('Acme')
+    })
+  })
+
+  describe('rowsToCsvBuffer', () => {
+    it('returns a buffer with escaped csv values', () => {
+      const buffer = rowsToCsvBuffer(
+        ['Name'],
+        [{ Name: 'Company, Inc.' }],
+        'members'
+      )
+      const content = buffer.toString('utf8')
+
+      expect(content).toContain('"Company, Inc."')
+    })
+  })
+})

--- a/node/utils/export/csvConverter.ts
+++ b/node/utils/export/csvConverter.ts
@@ -1,0 +1,200 @@
+import ExcelJS from 'exceljs'
+
+import type { ColumnDef } from './columnMappings'
+import {
+  getColumnMapping,
+  isMappedExportType,
+  mapRowToFields,
+} from './columnMappings'
+import type { ExportType } from './constants'
+import { buildExportFilename, UTF8_BOM } from './constants'
+
+const CUSTOM_FIELDS_HEADERS = new Set(['custom fields', 'customfields'])
+
+const getCellValue = (cell: ExcelJS.Cell) => {
+  const { value } = cell
+
+  if (value == null) {
+    return null
+  }
+
+  if (typeof value === 'object' && 'result' in value) {
+    return (value as ExcelJS.CellFormulaValue).result ?? null
+  }
+
+  if (typeof value === 'object' && 'richText' in value) {
+    return (value as ExcelJS.CellRichTextValue).richText
+      .map((item) => item.text)
+      .join('')
+  }
+
+  if (typeof value === 'object' && 'text' in value) {
+    return (value as ExcelJS.CellHyperlinkValue).text
+  }
+
+  return value
+}
+
+export const escapeCsvField = (value: string) => {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+
+  return value
+}
+
+export const serializeCellValue = (
+  value: unknown,
+  transform: ColumnDef['transform'] = 'default',
+  header?: string
+) => {
+  if (value == null || value === '') {
+    return ''
+  }
+
+  const normalizedHeader = header?.trim().toLowerCase().replace(/\s+/g, ' ')
+  const isCustomField =
+    transform === 'json' ||
+    (normalizedHeader && CUSTOM_FIELDS_HEADERS.has(normalizedHeader))
+
+  if (isCustomField) {
+    if (typeof value === 'string') {
+      return value
+    }
+
+    return JSON.stringify(value)
+  }
+
+  if (transform === 'array' || Array.isArray(value)) {
+    if (Array.isArray(value)) {
+      return value.map(String).join('|')
+    }
+
+    return String(value)
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+const buildCsvLine = (values: string[]) =>
+  values.map(escapeCsvField).join(',')
+
+const parseWorksheetRows = (worksheet: ExcelJS.Worksheet) => {
+  const headers: string[] = []
+  const rows: Array<Record<string, unknown>> = []
+
+  worksheet.eachRow((row, rowNumber) => {
+    if (rowNumber === 1) {
+      row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
+        headers[colNumber - 1] = String(getCellValue(cell) ?? '')
+      })
+
+      return
+    }
+
+    const rowData: Record<string, unknown> = {}
+
+    row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
+      const header = headers[colNumber - 1]
+
+      if (header) {
+        rowData[header] = getCellValue(cell)
+      }
+    })
+
+    rows.push(rowData)
+  })
+
+  return { headers: headers.filter(Boolean), rows }
+}
+
+const buildMappedCsv = (
+  rows: Array<Record<string, unknown>>,
+  exportType: ExportType
+) => {
+  const mapping = getColumnMapping(exportType)
+
+  if (!mapping) {
+    throw new Error(`Missing column mapping for export type: ${exportType}`)
+  }
+
+  const { columns, headerAliases } = mapping
+  const csvLines = [buildCsvLine(columns.map((column) => column.header))]
+
+  rows.forEach((rawRow) => {
+    const mappedRow = mapRowToFields(rawRow, headerAliases)
+    const values = columns.map((column) =>
+      serializeCellValue(mappedRow[column.field], column.transform, column.header)
+    )
+
+    csvLines.push(buildCsvLine(values))
+  })
+
+  return csvLines.join('\n')
+}
+
+const buildPassthroughCsv = (
+  headers: string[],
+  rows: Array<Record<string, unknown>>
+) => {
+  const csvLines = [buildCsvLine(headers)]
+
+  rows.forEach((row) => {
+    const values = headers.map((header) =>
+      serializeCellValue(row[header], 'default', header)
+    )
+
+    csvLines.push(buildCsvLine(values))
+  })
+
+  return csvLines.join('\n')
+}
+
+export const buildCsvContent = (
+  headers: string[],
+  rows: Array<Record<string, unknown>>,
+  exportType: ExportType
+) => {
+  const csvContent = isMappedExportType(exportType)
+    ? buildMappedCsv(rows, exportType)
+    : buildPassthroughCsv(headers, rows)
+
+  return `${UTF8_BOM}${csvContent}`
+}
+
+export const convertXlsxToCsv = async (
+  xlsxBuffer: Buffer,
+  exportType: ExportType
+) => {
+  const workbook = new ExcelJS.Workbook()
+
+  await workbook.xlsx.load(xlsxBuffer)
+
+  const worksheet = workbook.worksheets[0]
+
+  if (!worksheet) {
+    throw new Error('Export file contains no worksheets')
+  }
+
+  const { headers, rows } = parseWorksheetRows(worksheet)
+  const csvContent = buildCsvContent(headers, rows, exportType)
+
+  return {
+    buffer: Buffer.from(csvContent, 'utf8'),
+    filename: buildExportFilename(exportType),
+  }
+}
+
+export const rowsToCsvBuffer = (
+  headers: string[],
+  rows: Array<Record<string, unknown>>,
+  exportType: ExportType
+) => Buffer.from(buildCsvContent(headers, rows, exportType), 'utf8')

--- a/node/utils/export/ensureConvertedExport.ts
+++ b/node/utils/export/ensureConvertedExport.ts
@@ -1,0 +1,145 @@
+import { Readable } from 'stream'
+
+import { UserInputError } from '@vtex/api'
+
+import type { ExportMetadata, ExportType } from './constants'
+import {
+  EXPORT_CSV_VBASE_TTL_SECONDS,
+  EXPORT_STATUS,
+  EXPORT_VBASE_BUCKET,
+  getExportFilePath,
+} from './constants'
+import { convertXlsxToCsv } from './csvConverter'
+
+export const getExportMetadata = async (ctx: Context, exportId: string) => {
+  try {
+    return await ctx.clients.vbase.getJSON<ExportMetadata>(
+      EXPORT_VBASE_BUCKET,
+      exportId
+    )
+  } catch (error) {
+    const { data } = (error as any).response ?? {}
+
+    if (data?.code === 'FileNotFound') {
+      return null
+    }
+
+    throw error
+  }
+}
+
+export const hasConvertedFile = (metadata: ExportMetadata | null) =>
+  Boolean(metadata?.convertedAt && metadata?.filename)
+
+export const vbaseExportFileExists = async (ctx: Context, exportId: string) => {
+  try {
+    await ctx.clients.vbase.getFileMetadata(
+      EXPORT_VBASE_BUCKET,
+      getExportFilePath(exportId)
+    )
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const storeConvertedExport = async (
+  ctx: Context,
+  exportId: string,
+  exportType: ExportType,
+  csvBuffer: Buffer,
+  filename: string
+) => {
+  const filePath = getExportFilePath(exportId)
+  const metadata: ExportMetadata = {
+    convertedAt: new Date().toISOString(),
+    exportId,
+    exportType,
+    filename,
+    totalRows: null,
+  }
+
+  const existingMetadata = await getExportMetadata(ctx, exportId)
+
+  if (existingMetadata) {
+    metadata.totalRows = existingMetadata.totalRows
+  }
+
+  await ctx.clients.vbase.saveFile(
+    EXPORT_VBASE_BUCKET,
+    filePath,
+    Readable.from(csvBuffer),
+    false,
+    EXPORT_CSV_VBASE_TTL_SECONDS
+  )
+  await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, metadata)
+
+  return metadata
+}
+
+export const ensureExportIsConverted = async (
+  ctx: Context,
+  exportId: string
+) => {
+  const metadata = await getExportMetadata(ctx, exportId)
+  const fileExists = await vbaseExportFileExists(ctx, exportId)
+
+  console.log('[ensureExportIsConverted] start', {
+    exportId,
+    fileExists,
+    hasConvertedFile: hasConvertedFile(metadata),
+    hasExportType: Boolean(metadata?.exportType),
+  })
+
+  if (hasConvertedFile(metadata) && fileExists) {
+    return metadata as ExportMetadata
+  }
+
+  if (!metadata?.exportType) {
+    throw new UserInputError('Export metadata not found')
+  }
+
+  const statusResponse = await ctx.clients.bulkExport.getExportStatus(exportId)
+
+  console.log('[ensureExportIsConverted] bulk-import status', {
+    exportId,
+    linkToFile: statusResponse.linkToFile,
+    status: statusResponse.status,
+  })
+
+  if (
+    statusResponse.status !== EXPORT_STATUS.COMPLETED ||
+    !statusResponse.linkToFile
+  ) {
+    throw new UserInputError('Export is not ready for download')
+  }
+
+  const xlsxBuffer = await ctx.clients.bulkExport.downloadFile(
+    statusResponse.linkToFile
+  )
+
+  console.log('[ensureExportIsConverted] xlsx downloaded', {
+    exportId,
+    bytes: xlsxBuffer.length,
+  })
+
+  const { buffer, filename } = await convertXlsxToCsv(
+    xlsxBuffer,
+    metadata.exportType
+  )
+
+  console.log('[ensureExportIsConverted] csv converted', {
+    exportId,
+    bytes: buffer.length,
+    filename,
+  })
+
+  return storeConvertedExport(
+    ctx,
+    exportId,
+    metadata.exportType,
+    buffer,
+    filename
+  )
+}

--- a/node/utils/export/ensureConvertedExport.ts
+++ b/node/utils/export/ensureConvertedExport.ts
@@ -85,13 +85,6 @@ export const ensureExportIsConverted = async (
   const metadata = await getExportMetadata(ctx, exportId)
   const fileExists = await vbaseExportFileExists(ctx, exportId)
 
-  console.log('[ensureExportIsConverted] start', {
-    exportId,
-    fileExists,
-    hasConvertedFile: hasConvertedFile(metadata),
-    hasExportType: Boolean(metadata?.exportType),
-  })
-
   if (hasConvertedFile(metadata) && fileExists) {
     return metadata as ExportMetadata
   }
@@ -101,12 +94,6 @@ export const ensureExportIsConverted = async (
   }
 
   const statusResponse = await ctx.clients.bulkExport.getExportStatus(exportId)
-
-  console.log('[ensureExportIsConverted] bulk-import status', {
-    exportId,
-    linkToFile: statusResponse.linkToFile,
-    status: statusResponse.status,
-  })
 
   if (
     statusResponse.status !== EXPORT_STATUS.COMPLETED ||
@@ -119,21 +106,10 @@ export const ensureExportIsConverted = async (
     statusResponse.linkToFile
   )
 
-  console.log('[ensureExportIsConverted] xlsx downloaded', {
-    exportId,
-    bytes: xlsxBuffer.length,
-  })
-
   const { buffer, filename } = await convertXlsxToCsv(
     xlsxBuffer,
     metadata.exportType
   )
-
-  console.log('[ensureExportIsConverted] csv converted', {
-    exportId,
-    bytes: buffer.length,
-    filename,
-  })
 
   return storeConvertedExport(
     ctx,

--- a/node/utils/export/exportStatusCache.ts
+++ b/node/utils/export/exportStatusCache.ts
@@ -1,0 +1,132 @@
+import type { BulkExportStatusResponse } from '../../clients/bulkExport'
+import type { ExportMetadata, ExportStatusSnapshot } from './constants'
+import { EXPORT_STATUS, EXPORT_VBASE_BUCKET } from './constants'
+
+const SNAPSHOT_TTL_MS = 15 * 60 * 1000
+const SNAPSHOT_WRITE_INTERVAL_MS = 30 * 1000
+const SNAPSHOT_EXPORTED_ROWS_DELTA = 500
+
+const memorySnapshots = new Map<string, ExportStatusSnapshot>()
+
+const getCacheKey = (ctx: Context, exportId: string) =>
+  `${ctx.vtex.account}:${exportId}`
+
+const buildSnapshot = (
+  statusResponse: BulkExportStatusResponse
+): ExportStatusSnapshot => ({
+  capturedAt: new Date().toISOString(),
+  exportedRows: statusResponse.exportedRows ?? null,
+  lastUpdate: statusResponse.lastUpdate ?? null,
+  progressPercentage: statusResponse.progressPercentage ?? null,
+  startDate: statusResponse.startDate ?? null,
+  status: statusResponse.status,
+})
+
+export const isRecentSnapshot = (snapshot?: ExportStatusSnapshot) => {
+  if (!snapshot?.capturedAt) {
+    return false
+  }
+
+  return (
+    Date.now() - new Date(snapshot.capturedAt).getTime() < SNAPSHOT_TTL_MS
+  )
+}
+
+export const snapshotToStatusResponse = (
+  exportId: string,
+  snapshot: ExportStatusSnapshot
+): BulkExportStatusResponse => ({
+  exportId,
+  exportedRows: snapshot.exportedRows ?? undefined,
+  lastUpdate: snapshot.lastUpdate ?? undefined,
+  progressPercentage: snapshot.progressPercentage ?? undefined,
+  startDate: snapshot.startDate ?? undefined,
+  status: snapshot.status,
+})
+
+export const getCachedStatusSnapshot = (
+  ctx: Context,
+  exportId: string,
+  metadata?: ExportMetadata | null
+) => {
+  const memorySnapshot = memorySnapshots.get(getCacheKey(ctx, exportId))
+
+  if (memorySnapshot && isRecentSnapshot(memorySnapshot)) {
+    return memorySnapshot
+  }
+
+  const storedSnapshot = metadata?.lastStatusSnapshot
+
+  if (storedSnapshot && isRecentSnapshot(storedSnapshot)) {
+    return storedSnapshot
+  }
+
+  return null
+}
+
+const shouldPersistSnapshot = (
+  previous: ExportStatusSnapshot | undefined,
+  statusResponse: BulkExportStatusResponse
+) => {
+  if (
+    statusResponse.status === EXPORT_STATUS.COMPLETED ||
+    statusResponse.status === EXPORT_STATUS.FAILED
+  ) {
+    return true
+  }
+
+  if (!previous?.capturedAt) {
+    return true
+  }
+
+  if (previous.status !== statusResponse.status) {
+    return true
+  }
+
+  const elapsed = Date.now() - new Date(previous.capturedAt).getTime()
+
+  if (elapsed >= SNAPSHOT_WRITE_INTERVAL_MS) {
+    return true
+  }
+
+  const previousRows = previous.exportedRows ?? 0
+  const nextRows = statusResponse.exportedRows ?? 0
+
+  return Math.abs(nextRows - previousRows) >= SNAPSHOT_EXPORTED_ROWS_DELTA
+}
+
+export const saveStatusSnapshot = async (
+  ctx: Context,
+  exportId: string,
+  statusResponse: BulkExportStatusResponse,
+  metadata?: ExportMetadata | null
+) => {
+  const cacheKey = getCacheKey(ctx, exportId)
+  const resolvedMetadata = metadata ?? null
+  const previousSnapshot =
+    memorySnapshots.get(cacheKey) ?? resolvedMetadata?.lastStatusSnapshot
+  const snapshot = buildSnapshot(statusResponse)
+
+  memorySnapshots.set(cacheKey, snapshot)
+
+  if (!resolvedMetadata) {
+    return
+  }
+
+  if (!shouldPersistSnapshot(previousSnapshot, statusResponse)) {
+    return
+  }
+
+  try {
+    await ctx.clients.vbase.saveJSON(EXPORT_VBASE_BUCKET, exportId, {
+      ...resolvedMetadata,
+      lastStatusSnapshot: snapshot,
+    })
+  } catch (error) {
+    ctx.vtex.logger.warn({
+      error,
+      exportId,
+      message: 'exportStatus.snapshotPersistSkipped',
+    })
+  }
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -306,6 +306,31 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@fast-csv/format@4.3.5":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@fast-csv/format/-/format-4.3.5.tgz#90d83d1b47b6aaf67be70d6118f84f3e12ee1ff3"
+  integrity sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==
+  dependencies:
+    "@types/node" "^14.0.1"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+
+"@fast-csv/parse@4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@fast-csv/parse/-/parse-4.3.6.tgz#ee47d0640ca0291034c7aa94039a744cfb019264"
+  integrity sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==
+  dependencies:
+    "@types/node" "^14.0.1"
+    lodash.escaperegexp "^4.1.2"
+    lodash.groupby "^4.6.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+    lodash.isundefined "^3.0.1"
+    lodash.uniq "^4.5.0"
+
 "@grpc/grpc-js@^1.7.1":
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.13.4.tgz#922fbc496e229c5fa66802d2369bf181c1df1c5a"
@@ -1200,6 +1225,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
+"@types/node@^14.0.1":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+
 "@types/prettier@^2.1.5":
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
@@ -1512,6 +1542,22 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
+archiver-utils@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-3.0.4.tgz#a0d201f1cf8fce7af3b5a05aea0a337329e96ec7"
+  integrity sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==
+  dependencies:
+    glob "^7.2.3"
+    graceful-fs "^4.2.0"
+    lazystream "^1.0.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.union "^4.6.0"
+    normalize-path "^3.0.0"
+    readable-stream "^3.6.0"
+
 archiver@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz#9db7819d4daf60aec10fe86b16cb9258ced66ea0"
@@ -1524,6 +1570,19 @@ archiver@^3.0.0:
     readable-stream "^3.4.0"
     tar-stream "^2.1.0"
     zip-stream "^2.1.2"
+
+archiver@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.2.tgz#99991d5957e53bd0303a392979276ac4ddccf3b0"
+  integrity sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==
+  dependencies:
+    archiver-utils "^2.1.0"
+    async "^3.2.4"
+    buffer-crc32 "^0.2.1"
+    readable-stream "^3.6.0"
+    readdir-glob "^1.1.2"
+    tar-stream "^2.2.0"
+    zip-stream "^4.1.0"
 
 arg@^4.1.0:
   version "4.1.3"
@@ -1543,6 +1602,11 @@ async@^2.6.3:
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
+
+async@^3.2.4:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1642,6 +1706,19 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+big-integer@^1.6.17:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
+
+binary@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  integrity sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
+
 bintrees@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
@@ -1666,6 +1743,11 @@ bluebird@^3.5.4:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bluebird@~3.4.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+  integrity sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1673,6 +1755,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -1720,6 +1809,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer-indexof-polyfill@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz#d2732135c5999c64b277fcf9b1abe3498254729c"
+  integrity sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==
+
 buffer@^5.1.0, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -1727,6 +1821,11 @@ buffer@^5.1.0, buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+  integrity sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==
 
 bufrw@^1.3.0:
   version "1.3.0"
@@ -1798,6 +1897,13 @@ caniuse-lite@^1.0.30001489:
   version "1.0.30001492"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
   integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  integrity sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==
+  dependencies:
+    traverse ">=0.3.0 <0.4"
 
 chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
@@ -1925,6 +2031,16 @@ compress-commons@^2.1.1:
     normalize-path "^3.0.0"
     readable-stream "^2.3.6"
 
+compress-commons@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.2.tgz#6542e59cb63e1f46a8b21b0e06f9a32e4c8b06df"
+  integrity sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==
+  dependencies:
+    buffer-crc32 "^0.2.13"
+    crc32-stream "^4.0.2"
+    normalize-path "^3.0.0"
+    readable-stream "^3.6.0"
+
 compressible@^2.0.0:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -1972,12 +2088,25 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
 crc32-stream@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-3.0.1.tgz#cae6eeed003b0e44d739d279de5ae63b171b4e85"
   integrity sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==
   dependencies:
     crc "^3.4.4"
+    readable-stream "^3.4.0"
+
+crc32-stream@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.3.tgz#85dd677eb78fa7cad1ba17cc506a597d41fc6f33"
+  integrity sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==
+  dependencies:
+    crc-32 "^1.2.0"
     readable-stream "^3.4.0"
 
 crc@^3.4.4:
@@ -2036,6 +2165,11 @@ dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
+dayjs@^1.8.34:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   version "4.3.4"
@@ -2158,6 +2292,13 @@ dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==
+  dependencies:
+    readable-stream "^2.0.2"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2292,6 +2433,21 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+exceljs@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/exceljs/-/exceljs-4.4.0.tgz#cfb1cb8dcc82c760a9fc9faa9e52dadab66b0156"
+  integrity sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==
+  dependencies:
+    archiver "^5.0.0"
+    dayjs "^1.8.34"
+    fast-csv "^4.3.1"
+    jszip "^3.10.1"
+    readable-stream "^3.6.0"
+    saxes "^5.0.1"
+    tmp "^0.2.0"
+    unzipper "^0.10.11"
+    uuid "^8.3.0"
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2321,6 +2477,14 @@ expect@^27.5.1:
     jest-get-type "^27.5.1"
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
+
+fast-csv@^4.3.1:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-4.3.6.tgz#70349bdd8fe4d66b1130d8c91820b64a21bc4a63"
+  integrity sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==
+  dependencies:
+    "@fast-csv/format" "4.3.5"
+    "@fast-csv/parse" "4.3.6"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -2418,6 +2582,16 @@ fsevents@^2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -2482,7 +2656,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2504,7 +2678,7 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2690,6 +2864,11 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-in-the-middle@^1.8.1:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz#283661625a88ff7c0462bd2984f77715c3bc967c"
@@ -2726,7 +2905,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3348,6 +3527,16 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keygrip@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
@@ -3456,10 +3645,22 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+listenercount@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
+  integrity sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -3483,15 +3684,50 @@ lodash.difference@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
   integrity sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
+
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
 
+lodash.groupby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+  integrity sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isundefined@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz#23ef3d9535565203a66cefd5b830f848911afb48"
+  integrity sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -3502,6 +3738,11 @@ lodash.union@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
 lodash@^4.17.14, lodash@^4.7.0:
   version "4.17.21"
@@ -3603,6 +3844,13 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.1.0:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.1.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -3613,7 +3861,7 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -3743,6 +3991,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parse-json@^5.2.0:
   version "5.2.0"
@@ -3935,7 +4188,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -3948,7 +4201,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -3956,6 +4209,13 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdir-glob@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.3.tgz#c3d831f51f5e7bfa62fa2ffbe4b508c640f09584"
+  integrity sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==
+  dependencies:
+    minimatch "^5.1.0"
 
 redis@^0.12.1:
   version "0.12.1"
@@ -4021,6 +4281,13 @@ resolve@^1.22.8:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+rimraf@2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -4081,6 +4348,11 @@ semver@^7.5.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+setimmediate@^1.0.5, setimmediate@~1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -4286,7 +4558,7 @@ tar-fs@^2.0.0:
     pump "^3.0.0"
     tar-stream "^2.1.4"
 
-tar-stream@^2.1.0, tar-stream@^2.1.4:
+tar-stream@^2.1.0, tar-stream@^2.1.4, tar-stream@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -4335,6 +4607,11 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.2.tgz#51a3fbb5e11ae72e2cf74861ed5c8020f89f29fe"
   integrity sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==
 
+tmp@^0.2.0:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -4381,6 +4658,11 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==
 
 ts-invariant@^0.4.0:
   version "0.4.4"
@@ -4552,6 +4834,22 @@ unpipe@1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
+unzipper@^0.10.11:
+  version "0.10.14"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.14.tgz#d2b33c977714da0fbc0f82774ad35470a7c962b1"
+  integrity sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    graceful-fs "^4.2.2"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
+
 update-browserslist-db@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
@@ -4578,7 +4876,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@8.3.2, uuid@^8.3.2:
+uuid@8.3.2, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -4819,3 +5117,12 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+zip-stream@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.1.tgz#1337fe974dbaffd2fa9a1ba09662a66932bd7135"
+  integrity sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==
+  dependencies:
+    archiver-utils "^3.0.4"
+    compress-commons "^4.1.2"
+    readable-stream "^3.6.0"


### PR DESCRIPTION
#### What problem is this solving?

The B2B Admin needs to export organizations, cost centers, members, and addresses as CSV, but the export engine lives in `b2b-bulk-import` (REST + XLSX). The admin frontend should not call that service directly or handle file conversion.

This PR adds a GraphQL layer in `b2b-organizations-graphql` that:

- Exposes `createExport` and `exportStatus` for all four export types
- Proxies `b2b-bulk-import` with admin auth
- Converts completed XLSX exports to UTF-8 CSV (with BOM) on first download
- Serves files via `GET /_v/private/b2b/export/:exportId`
- Normalizes columns for `organizations` and `cost_centers`; passes through `members` and `addresses` as returned by bulk-import
- Caches converted CSV in VBase (5-minute TTL) and throttles status snapshot writes to avoid VBase rate limits during polling

This unblocks the frontend export button work in `b2b-organizations`.

#### How to test it?

**Workspace:** `https://wender--b2bstoreqa.myvtex.com` (link this branch with `vtex link`)

**Prerequisites:** Admin user with `buyer_organization_view`; `b2b-bulk-import` available on the account.

1. **Start an export** (Admin GraphQL IDE or curl):

```graphql
mutation CreateExport($exportType: ExportType!) {
  createExport(exportType: $exportType) {
    exportId
  }
}
```

Variables: `{ "exportType": "organizations" }` (repeat for `cost_centers`, `members`, `addresses`).

2. **Poll until complete:**

```graphql
query ExportStatus($exportId: String!) {
  exportStatus(exportId: $exportId) {
    status
    progressPercentage
    exportedRows
    linkToFile
  }
}
```

- Expect `IN_PROGRESS` → `COMPLETED`
- `linkToFile` should appear only when `status === COMPLETED`
- Progress may be computed from `exportedRows / totalRows` when bulk-import returns `0%`

3. **Download CSV:** open `linkToFile` in the browser while logged into Admin, or:

```bash
curl -O -J 'https://wender--b2bstoreqa.myvtex.com/_v/private/b2b/export/{exportId}' \
  -H 'cookie: VtexIdclientAutCookie=...'
```

- First download may take a few seconds (XLSX fetch + conversion)
- CSV should have UTF-8 BOM and normalized headers for orgs/cost centers
- Second download within 5 minutes should be faster (VBase cache)

4. **Auth:** unauthenticated download should return `403 Access denied`.

5. **Unit tests:** `yarn test` in `node/` (includes `csvConverter.test.ts`).

See `docs/README.md` for full API details.

[Workspace](https://wender--b2bstoreqa.myvtex.com/admin/b2b-organizations/organizations#/organizations)

#### Screenshots or example usage:

<img width="1547" height="943" alt="image" src="https://github.com/user-attachments/assets/0208227e-5305-49df-b10e-1b5085cc884c" />
