### PR TITLE
Feature/b2 bteam 3598 major based schema

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "lastRunAtMs": 0,
-  "turnsSinceLastRun": 2,
+  "turnsSinceLastRun": 8,
   "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "018f5be8-02d5-446a-8916-916315204541",
+  "lastProcessedGenerationId": "b7ec79f7-071f-481e-81a0-42cc0c219bc7",
   "trialStartedAtMs": null
 }

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 2,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "018f5be8-02d5-446a-8916-916315204541",
+  "trialStartedAtMs": null
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ node/package-lock.json
 react/package-lock.json
 cy-runner
 /node/coverage/
+.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schema auto-update**: scope VBase hash storage by app major version (`settings-v{N}`) so accounts running two majors of the app no longer trigger an infinite Master Data schema update loop.
+- **Master Data schemas**: bump schema versions to `v2.x` so v2 app instances use dedicated schemas instead of legacy `v0.x` versions that could be overwritten by another major.
+
 ## [2.5.0] - 2026-06-25
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "vtex",
-  "version": "2.5.0",
+  "version": "2.5.1-hkignore.0",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -15,7 +15,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'sellers',
   'customFields',
 ]
-export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.1'
+export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v2.1.1'
 
 export const ORGANIZATION_DATA_ENTITY = 'organizations'
 export const ORGANIZATION_FIELDS = [
@@ -33,7 +33,7 @@ export const ORGANIZATION_FIELDS = [
   'customFields',
   'permissions',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.8'
+export const ORGANIZATION_SCHEMA_VERSION = 'v2.0.8'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -48,7 +48,7 @@ export const COST_CENTER_FIELDS = [
   'stateRegistration',
   'sellers',
 ]
-export const COST_CENTER_SCHEMA_VERSION = 'v0.0.8'
+export const COST_CENTER_SCHEMA_VERSION = 'v2.0.8'
 
 export const schemas = [
   {

--- a/node/package.json
+++ b/node/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.0",
   "dependencies": {
     "@types/lodash": "4.14.74",
-    "@vtex/api": "6.50.1",
+    "@vtex/api": "6.51.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.12.21",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.50.1",
+    "@vtex/api": "6.51.0",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "jest": "27.5.1",

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -6,7 +6,7 @@ import {
 } from '../../mdSchema'
 import { toHash } from '../../utils'
 import GraphQLError, { getErrorMessage } from '../../utils/GraphQLError'
-import { getAppId } from '../config'
+import { getAppId, getAppMajorVersion } from '../config'
 
 const SCROLL_AWAIT_TIME = 100
 const SLEEP_ADD_PERCENTAGE = 0.1
@@ -189,12 +189,16 @@ const Users = {
       settings.adminSetup = {}
     }
 
+    const majorVersion = getAppMajorVersion()
     const currHash = toHash(schemas)
 
-    if (
-      !settings.adminSetup?.schemaHash ||
-      settings.adminSetup?.schemaHash !== currHash
-    ) {
+    if (!settings.adminSetup.schemaHashes) {
+      settings.adminSetup.schemaHashes = {}
+    }
+
+    const storedSchemaHash = settings.adminSetup.schemaHashes[majorVersion]
+
+    if (!storedSchemaHash || storedSchemaHash !== currHash) {
       const updates: any = []
 
       schemas.forEach((schema) => {
@@ -218,7 +222,7 @@ const Users = {
 
       await Promise.all(updates)
         .then(() => {
-          settings.adminSetup.schemaHash = currHash
+          settings.adminSetup.schemaHashes[majorVersion] = currHash
         })
         .catch((e) => {
           if (e.response.status !== 304) {

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -13,7 +13,7 @@ const SLEEP_ADD_PERCENTAGE = 0.1
 const SCROLL_SIZE = 1000
 
 const USER_DATA_ENTITY = 'b2b_users'
-const USER_DATA_ENTITY_SCHEMA = 'v0.1.2'
+const USER_DATA_ENTITY_SCHEMA = 'v3.1.2'
 
 // This function checks if given email is an user part of a buyer org.
 export const isUserPartOfBuyerOrg = async (email: string, ctx: Context) => {

--- a/node/resolvers/config.ts
+++ b/node/resolvers/config.ts
@@ -19,13 +19,32 @@ export const getAppId = (): string => {
   return appName
 }
 
+export const getAppMajorVersion = (): string => {
+  const appId = process.env.VTEX_APP_ID
+  const [, version] = String(appId).split('@')
+
+  if (!version) {
+    return '0'
+  }
+
+  const [major] = version.split('.')
+
+  return major ?? '0'
+}
+
+const getSchemaSettingsKey = (): string => {
+  return `settings-v${getAppMajorVersion()}`
+}
+
 const checkConfig = async (ctx: Context) => {
   const {
     vtex: { logger },
     clients: { mail, masterdata, vbase },
   } = ctx
 
-  let settings: Settings = await vbase.getJSON('mdSchema', 'settings', true)
+  const settingsKey = getSchemaSettingsKey()
+
+  let settings: Settings = await vbase.getJSON('mdSchema', settingsKey, true)
 
   let schemaChanged = false
   let templatesChanged = false
@@ -124,7 +143,7 @@ const checkConfig = async (ctx: Context) => {
 
   if (schemaChanged || templatesChanged) {
     try {
-      await vbase.saveJSON('mdSchema', 'settings', settings)
+      await vbase.saveJSON('mdSchema', settingsKey, settings)
     } catch (error) {
       logger.error({
         error,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1249,10 +1249,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.50.1":
-  version "6.50.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.50.1.tgz#a86578982a7aac7c7a8df2b9ec3df18bc43f01f2"
-  integrity sha512-4IlmYwCXKpkdpN2KN6NkPuRwnjet3ilSoET3PBOTTdZqE/mnuvIxRZRaQy+Yp7Gxu0XKAVdp/8SQJhsJaa6Unw==
+"@vtex/api@6.51.0":
+  version "6.51.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.51.0.tgz#97aeb306619ff49fd890595b90568883eaf77d83"
+  integrity sha512-vRWKB4G1FPPt67rwWx+xGLanuP5y+M9SVmbKu3PzlTrqgq/aW/mINSUGa/Nhm64UBqIQCkVic7/smZ7kKFq52w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4158,9 +4158,9 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
-  version "2.2.0"
-  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
+"stats-lite@github:vtex/node-stats-lite#dist":
+  version "2.2.1"
+  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:
     isnumber "~1.0.0"
 


### PR DESCRIPTION
#### What problem is this solving?

Accounts running **two different majors** of `b2b-organizations-graphql` (e.g. v1.x and v2.x during migration) share the same VBase hash used by the automatic Master Data schema sync. Each major computes a different schema hash, sees a mismatch, updates schemas to its own definition, overwrites the shared hash, and triggers the other major again — causing an **infinite schema update loop**.

Additionally, v2 was still using legacy `v0.x` Master Data schema versions (`v0.0.8`, `v0.1.1`), which could be overwritten by another major installed on the same account.

This PR fixes both issues by:

1. **Scoping hash storage by app major version** — VBase key changes from `mdSchema/settings` to `mdSchema/settings-v{N}` (e.g. `settings-v2`), and `getAppSettings` stores hashes per major in `adminSetup.schemaHashes[majorVersion]`.
2. **Bumping Master Data schema versions to v2** — `organizations` and `cost_centers` move to `v2.0.8`, `organization_requests` to `v2.1.1`, so v2 instances register and use dedicated schemas independent from v0/v1.

#### How to test it?

[Workspace](https://wender--b2bstoreqa.myvtex.com/admin/graphql-ide)

1. Link this branch and open the GraphQL IDE.
2. Run `getAppSettings` or `getB2BSettings` to trigger schema registration.
3. Confirm VBase bucket `mdSchema` has key `settings-v2` with `schemaHash` and `templateHash`.
4. Confirm Master Data schemas exist:
   - `GET /api/dataentities/organizations/schemas/v2.0.8`
   - `GET /api/dataentities/cost_centers/schemas/v2.0.8`
   - `GET /api/dataentities/organization_requests/schemas/v2.1.1`
5. Run mutations and verify documents are created/read successfully:
   - `createOrganization` → `getOrganizationById`
   - `createOrganizationRequest` → `getOrganizationRequestById`
   - `createCostCenter` → `getCostCenterById`
6. Confirm IO logs show `checkConfig-updatingSchema` only once (first request), not on every subsequent request.
7. _(If dual-major scenario is available)_ With v1 and v2 installed on the same account, confirm each major uses its own VBase key and schema versions without looping.

**Unit tests:**

```bash
cd node && npm test -- Organizations.test.ts
```

#### Screenshots or example usage:

<img width="1094" height="917" alt="image" src="https://github.com/user-attachments/assets/463d9314-a5aa-438b-abd7-08714518e7cb" />
<img width="1189" height="420" alt="image" src="https://github.com/user-attachments/assets/8039072f-010a-41ba-9b18-740936dc2a12" />

