### PR TITLE
revert(schema): hold previous schema version names in mdSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Master Data schemas**: roll back `ORGANIZATION_REQUEST_SCHEMA_VERSION`, `ORGANIZATION_SCHEMA_VERSION` and `COST_CENTER_SCHEMA_VERSION` to their previous `v0.x` names. The `v2.x` rename introduced in 2.6.0 (`B2BTEAM-3598`, major-based schemas) caused issues with the Master Data indexer in production. Holding the `v0.x` names until it's safe to roll forward again.
+
 ## [2.6.0] - 2026-07-10
 
 ### Fixed

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -15,7 +15,7 @@ export const ORGANIZATION_REQUEST_FIELDS = [
   'sellers',
   'customFields',
 ]
-export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v2.1.1'
+export const ORGANIZATION_REQUEST_SCHEMA_VERSION = 'v0.1.1'
 
 export const ORGANIZATION_DATA_ENTITY = 'organizations'
 export const ORGANIZATION_FIELDS = [
@@ -33,7 +33,7 @@ export const ORGANIZATION_FIELDS = [
   'customFields',
   'permissions',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v2.0.8'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.8'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -48,7 +48,7 @@ export const COST_CENTER_FIELDS = [
   'stateRegistration',
   'sellers',
 ]
-export const COST_CENTER_SCHEMA_VERSION = 'v2.0.8'
+export const COST_CENTER_SCHEMA_VERSION = 'v0.0.8'
 
 export const schemas = [
   {


### PR DESCRIPTION
#### What problem is this solving?

The Master Data schema version bump introduced in 62388ba (`B2BTEAM-3598`, "major-based schemas", released in `2.6.0`) renamed `ORGANIZATION_REQUEST_SCHEMA_VERSION`, `ORGANIZATION_SCHEMA_VERSION` and `COST_CENTER_SCHEMA_VERSION` from `v0.x` to `v2.x`. This caused issues with the Master Data indexer in production.

This PR isolates just the schema-version rollback (same change already written as commit `244c956` on `fix/B2BTEAM-3729-async-audit-event` / PR #229), without bundling the unrelated audit fire-and-forget / login-timeout fix from that PR, so it can be reviewed and merged independently and unblock:

- B2BTEAM-3550 (already merged, unaffected — predates the `v2.x` bump)
- B2BTEAM-3591 (PR #228, open) — currently branched from a state that carries the `v2.x` bump

#### What changed

- `node/mdSchema.ts`: `ORGANIZATION_REQUEST_SCHEMA_VERSION`, `ORGANIZATION_SCHEMA_VERSION`, `COST_CENTER_SCHEMA_VERSION` back to `v0.1.1` / `v0.0.8` / `v0.0.8`.
- `CHANGELOG.md`: entry documenting the rollback.

#### How to test it?

Confirm `ORGANIZATION_REQUEST_SCHEMA_VERSION`, `ORGANIZATION_SCHEMA_VERSION` and `COST_CENTER_SCHEMA_VERSION` are back to `v0.x` and schema creation/update behaves as before 62388ba.

#### Related to / Depends on

- Reverts part of 62388ba / B2BTEAM-3598 (major-based schemas) — schema version names only
- Unblocks B2BTEAM-3591 / PR #228